### PR TITLE
8290496: riscv: Fix build warnings-as-errors with GCC 11

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -311,18 +311,14 @@ class NativeCall: public NativeInstruction {
 inline NativeCall* nativeCall_at(address addr) {
   assert_cond(addr != NULL);
   NativeCall* call = (NativeCall*)(addr - NativeCall::instruction_offset);
-#ifdef ASSERT
-  call->verify();
-#endif
+  DEBUG_ONLY(call->verify());
   return call;
 }
 
 inline NativeCall* nativeCall_before(address return_address) {
   assert_cond(return_address != NULL);
   NativeCall* call = (NativeCall*)(return_address - NativeCall::return_address_offset);
-#ifdef ASSERT
-  call->verify();
-#endif
+  DEBUG_ONLY(call->verify());
   return call;
 }
 
@@ -362,7 +358,7 @@ class NativeMovConstReg: public NativeInstruction {
   }
 
   intptr_t data() const;
-  void  set_data(intptr_t x);
+  void set_data(intptr_t x);
 
   void flush() {
     if (!maybe_cpool_ref(instruction_address())) {
@@ -370,8 +366,8 @@ class NativeMovConstReg: public NativeInstruction {
     }
   }
 
-  void  verify();
-  void  print();
+  void verify();
+  void print();
 
   // Creation
   inline friend NativeMovConstReg* nativeMovConstReg_at(address addr);
@@ -381,55 +377,53 @@ class NativeMovConstReg: public NativeInstruction {
 inline NativeMovConstReg* nativeMovConstReg_at(address addr) {
   assert_cond(addr != NULL);
   NativeMovConstReg* test = (NativeMovConstReg*)(addr - NativeMovConstReg::instruction_offset);
-#ifdef ASSERT
-  test->verify();
-#endif
+  DEBUG_ONLY(test->verify());
   return test;
 }
 
 inline NativeMovConstReg* nativeMovConstReg_before(address addr) {
   assert_cond(addr != NULL);
   NativeMovConstReg* test = (NativeMovConstReg*)(addr - NativeMovConstReg::instruction_size - NativeMovConstReg::instruction_offset);
-#ifdef ASSERT
-  test->verify();
-#endif
+  DEBUG_ONLY(test->verify());
   return test;
 }
 
-// RISCV should not use C1 runtime patching, so just leave NativeMovRegMem Unimplemented.
+// RISCV should not use C1 runtime patching, but still implement
+// NativeMovRegMem to keep some compilers happy.
 class NativeMovRegMem: public NativeInstruction {
  public:
-  int instruction_start() const {
-    Unimplemented();
-    return 0;
-  }
+  enum RISCV_specific_constants {
+    instruction_size            =    NativeInstruction::instruction_size,
+    instruction_offset          =    0,
+    data_offset                 =    0,
+    next_instruction_offset     =    NativeInstruction::instruction_size
+  };
 
-  address instruction_address() const {
-    Unimplemented();
-    return NULL;
-  }
+  int instruction_start() const { return instruction_offset; }
 
-  int num_bytes_to_end_of_patch() const {
-    Unimplemented();
-    return 0;
-  }
+  address instruction_address() const { return addr_at(instruction_offset); }
+
+  int num_bytes_to_end_of_patch() const { return instruction_offset + instruction_size; }
 
   int offset() const;
 
   void set_offset(int x);
 
-  void add_offset_in_bytes(int add_offset) { Unimplemented(); }
+  void add_offset_in_bytes(int add_offset) {
+    set_offset(offset() + add_offset);
+  }
 
   void verify();
   void print();
 
  private:
-  inline friend NativeMovRegMem* nativeMovRegMem_at (address addr);
+  inline friend NativeMovRegMem* nativeMovRegMem_at(address addr);
 };
 
-inline NativeMovRegMem* nativeMovRegMem_at (address addr) {
-  Unimplemented();
-  return NULL;
+inline NativeMovRegMem* nativeMovRegMem_at(address addr) {
+  NativeMovRegMem* test = (NativeMovRegMem*)(addr - NativeMovRegMem::instruction_offset);
+  DEBUG_ONLY(test->verify());
+  return test;
 }
 
 class NativeJump: public NativeInstruction {
@@ -460,9 +454,7 @@ class NativeJump: public NativeInstruction {
 
 inline NativeJump* nativeJump_at(address addr) {
   NativeJump* jump = (NativeJump*)(addr - NativeJump::instruction_offset);
-#ifdef ASSERT
-  jump->verify();
-#endif
+  DEBUG_ONLY(jump->verify());
   return jump;
 }
 

--- a/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
@@ -171,7 +171,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   assert(VtableStub::receiver_location() == j_rarg0->as_VMReg(), "receiver expected in j_rarg0");
 
   // Entry arguments:
-  //  t2: CompiledICHolder
+  //  t1: CompiledICHolder
   //  j_rarg0: Receiver
 
   // This stub is called from compiled code which has no callee-saved registers,


### PR DESCRIPTION
Hi, Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8290496](https://bugs.openjdk.java.net/browse/JDK-8290496). Applies cleanly.
build config:
```
bash configure --with-debug-level=release --with-jvm-variants=minimal --with-zlib=system --with-native-debug-symbols=internal --with-boot-jdk=/home/zifeihan/jre/jre11 --with-extra-cxxflags=-Wno-maybe-uninitialized --with-extra-cflags=-Wno-maybe-uninitialized
```

Before this backport:
```

ERROR: Build failed for target 'default (exploded-image)' in configuration 'linux-riscv64-normal-minimal-release' (exit code 2)
Stopping sjavac server

=== Output from failing command(s) repeated here ===
* For target hotspot_variant-minimal_libjvm_objs_c1_LIRAssembler.o:
In file included from /home/zifeihan/riscv-port-jdk11u/src/hotspot/share/c1/c1_LIRAssembler.hpp:28,
                 from /home/zifeihan/riscv-port-jdk11u/src/hotspot/share/c1/c1_LIRAssembler.cpp:30:
In member function 'void PatchingStub::install(MacroAssembler*, LIR_PatchCode, Register, CodeEmitInfo*)',
    inlined from 'void LIR_Assembler::patching_epilog(PatchingStub*, LIR_PatchCode, Register, CodeEmitInfo*)' at /home/zifeihan/riscv-port-jdk11u/src/hotspot/share/c1/c1_LIRAssembler.cpp:45:17:
/home/zifeihan/riscv-port-jdk11u/src/hotspot/share/c1/c1_CodeStubs.hpp:423:25: error: 'this' pointer is null [-Werror=nonnull]
  423 |       n_move->set_offset(field_offset);
      |       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
In file included from /home/zifeihan/riscv-port-jdk11u/src/hotspot/share/code/nativeInst.hpp:30,
                 from /home/zifeihan/riscv-port-jdk11u/src/hotspot/share/precompiled/precompiled.hpp:77:
/home/zifeihan/riscv-port-jdk11u/src/hotspot/cpu/riscv/nativeInst_riscv.hpp: In member function 'void LIR_Assembler::patching_epilog(PatchingStub*, LIR_PatchCode, Register, CodeEmitInfo*)':
/home/zifeihan/riscv-port-jdk11u/src/hotspot/cpu/riscv/nativeInst_riscv.hpp:419:8: note: in a call to non-static member function 'void NativeMovRegMem::set_offset(int)'
  419 |   void set_offset(int x);
      |        ^~~~~~~~~~
cc1plus: all warnings being treated as errors

* All command lines available in /home/zifeihan/riscv-port-jdk11u/build/linux-riscv64-normal-minimal-release/make-support/failure-logs.
=== End of repeated output ===

No indication of failed target found.
Hint: Try searching the build log for '] Error'.
Hint: See doc/building.html#troubleshooting for assistance.

make[1]: *** [/home/zifeihan/riscv-port-jdk11u/make/Init.gmk:308: main] Error 2
make: *** [/home/zifeihan/riscv-port-jdk11u/make/Init.gmk:186: default] Error 2
```

After this backport,  We can build successful.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290496](https://bugs.openjdk.org/browse/JDK-8290496): riscv: Fix build warnings-as-errors with GCC 11 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/7.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/7.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/7#issuecomment-1975064760)