### PR TITLE
8327284: Use correct register in riscv_enc_fast_unlock()

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2155,7 +2155,7 @@ encode %{
     // Handle existing monitor.
     if ((EmitSync & 0x02) == 0) {
       __ ld(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
-      __ andi(t0, disp_hdr, markOopDesc::monitor_value);
+      __ andi(t0, tmp, markOopDesc::monitor_value);
       __ bnez(t0, object_has_monitor);
     }
 


### PR DESCRIPTION
Hi, The same issue also exists in the riscv-port-jdk11u. It's already fixed in the jdk17u version above, for performance reasons, I'd like to backport it to this repo.

Testing:

- [x] Run tier1 tests on SOPHGO SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327284](https://bugs.openjdk.org/browse/JDK-8327284): Use correct register in riscv_enc_fast_unlock() (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/8.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/8.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/8#issuecomment-1976421351)