### PR TITLE
8316645: RISC-V: Remove dependency on libatomic by adding cmpxchg 1b

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -130,12 +130,6 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lthread"
   fi
 
-  # Because RISC-V only has word-sized atomics, it requries libatomic where
-  # other common architectures do not.  So link libatomic by default.
-  if test "x$OPENJDK_TARGET_OS" = xlinux && test "x$OPENJDK_TARGET_CPU" = xriscv64; then
-    BASIC_JVM_LIBS="$BASIC_JVM_LIBS -latomic"
-  fi
-
   # perfstat lib
   if test "x$OPENJDK_TARGET_OS" = xaix; then
     BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lperfstat"

--- a/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
@@ -69,9 +69,9 @@ struct Atomic::PlatformAdd
 #ifndef FULL_COMPILER_ATOMIC_SUPPORT
 template<>
 template<typename T>
-inline T Atomic::PlatformCmpxchg<1>::operator()(T volatile* dest __attribute__((unused)),
+inline T Atomic::PlatformCmpxchg<1>::operator()(T exchange_value,
+                                                T volatile* dest __attribute__((unused)),
                                                 T compare_value,
-                                                T exchange_value,
                                                 atomic_memory_order order) const {
   STATIC_ASSERT(1 == sizeof(T));
 
@@ -185,4 +185,5 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T exchange_value,
   return rv;
 }
 
+#undef FULL_COMPILER_ATOMIC_SUPPORT
 #endif // OS_CPU_LINUX_RISCV_ATOMIC_LINUX_RISCV_HPP

--- a/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
@@ -33,6 +33,12 @@
 // Note that memory_order_conservative requires a full barrier after atomic stores.
 // See https://patchwork.kernel.org/patch/3575821/
 
+#if defined(__clang_major__)
+#define FULL_COMPILER_ATOMIC_SUPPORT
+#elif (__GNUC__ > 13) || ((__GNUC__ == 13) && (__GNUC_MINOR__ >= 2))
+#define FULL_COMPILER_ATOMIC_SUPPORT
+#endif
+
 #define FULL_MEM_BARRIER  __sync_synchronize()
 #define READ_MEM_BARRIER  __atomic_thread_fence(__ATOMIC_ACQUIRE);
 #define WRITE_MEM_BARRIER __atomic_thread_fence(__ATOMIC_RELEASE);
@@ -43,6 +49,12 @@ struct Atomic::PlatformAdd
 {
   template<typename I, typename D>
   D add_and_fetch(I add_value, D volatile* dest, atomic_memory_order order) const {
+#ifndef FULL_COMPILER_ATOMIC_SUPPORT
+    // If we add add and fetch for sub word and are using older compiler
+    // it must be added here due to not using lib atomic.
+    STATIC_ASSERT(byte_size >= 4);
+#endif
+
     D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
     FULL_MEM_BARRIER;
     return res;
@@ -54,11 +66,63 @@ struct Atomic::PlatformAdd
   }
 };
 
+#ifndef FULL_COMPILER_ATOMIC_SUPPORT
+template<>
+template<typename T>
+inline T Atomic::PlatformCmpxchg<1>::operator()(T volatile* dest __attribute__((unused)),
+                                                T compare_value,
+                                                T exchange_value,
+                                                atomic_memory_order order) const {
+  STATIC_ASSERT(1 == sizeof(T));
+
+  if (order != memory_order_relaxed) {
+    FULL_MEM_BARRIER;
+  }
+
+  uint32_t volatile* aligned_dst = (uint32_t volatile*)(((uintptr_t)dest) & (~((uintptr_t)0x3)));
+  int shift = 8 * (((uintptr_t)dest) - ((uintptr_t)aligned_dst)); // 0, 8, 16, 24
+
+  uint64_t mask = 0xfful << shift; // 0x00000000..FF..
+  uint64_t remask = ~mask;         // 0xFFFFFFFF..00..
+
+  uint64_t w_cv = ((uint64_t)(unsigned char)compare_value) << shift;  // widen to 64-bit 0x00000000..CC..
+  uint64_t w_ev = ((uint64_t)(unsigned char)exchange_value) << shift; // widen to 64-bit 0x00000000..EE..
+
+  uint64_t old_value;
+  uint64_t rc_temp;
+
+  __asm__ __volatile__ (
+    "1:  lr.w      %0, %2      \n\t"
+    "    and       %1, %0, %5  \n\t" // ignore unrelated bytes and widen to 64-bit 0x00000000..XX..
+    "    bne       %1, %3, 2f  \n\t" // compare 64-bit w_cv
+    "    and       %1, %0, %6  \n\t" // remove old byte
+    "    or        %1, %1, %4  \n\t" // add new byte
+    "    sc.w      %1, %1, %2  \n\t" // store new word
+    "    bnez      %1, 1b      \n\t"
+    "2:                        \n\t"
+    : /*%0*/"=&r" (old_value), /*%1*/"=&r" (rc_temp), /*%2*/"+A" (*aligned_dst)
+    : /*%3*/"r" (w_cv), /*%4*/"r" (w_ev), /*%5*/"r" (mask), /*%6*/"r" (remask)
+    : "memory" );
+
+  if (order != memory_order_relaxed) {
+    FULL_MEM_BARRIER;
+  }
+
+  return (T)((old_value & mask) >> shift);
+}
+#endif
+
 template<size_t byte_size>
 template<typename T>
 inline T Atomic::PlatformXchg<byte_size>::operator()(T exchange_value,
                                                      T volatile* dest,
                                                      atomic_memory_order order) const {
+#ifndef FULL_COMPILER_ATOMIC_SUPPORT
+  // If we add xchg for sub word and are using older compiler
+  // it must be added here due to not using lib atomic.
+  STATIC_ASSERT(byte_size >= 4);
+#endif
+
   STATIC_ASSERT(byte_size == sizeof(T));
   T res = __atomic_exchange_n(dest, exchange_value, __ATOMIC_RELEASE);
   FULL_MEM_BARRIER;
@@ -72,6 +136,11 @@ inline T Atomic::PlatformCmpxchg<byte_size>::operator()(T exchange_value,
                                                         T volatile* dest __attribute__((unused)),
                                                         T compare_value,
                                                         atomic_memory_order order) const {
+
+#ifndef FULL_COMPILER_ATOMIC_SUPPORT
+  STATIC_ASSERT(byte_size >= 4);
+#endif
+
   STATIC_ASSERT(byte_size == sizeof(T));
   T value = compare_value;
   if (order != memory_order_relaxed) {


### PR DESCRIPTION
For CI builds it helps to remove this.
[8317335](https://bugs.openjdk.org/browse/JDK-8317335) is not needed as there is no gtest for atomic in 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316645](https://bugs.openjdk.org/browse/JDK-8316645): RISC-V: Remove dependency on libatomic by adding cmpxchg 1b (**Enhancement** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - no project role) ⚠️ Review applies to [3f2651e4](https://git.openjdk.org/riscv-port-jdk11u/pull/10/files/3f2651e49f4e2d6eb6e1e6dec5480df03474105b)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/10.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/10.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/10#issuecomment-1983388677)