### PR TITLE
8283865: riscv: Break down -XX:+UseRVB into seperate options for each bitmanip extension

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1945,6 +1945,7 @@ enum Nf {
 
 // ====================================
 // RISC-V Bit-Manipulation Extension
+// Currently only support Zba and Zbb.
 // ====================================
 #define INSN(NAME, op, funct3, funct7)                  \
   void NAME(Register Rd, Register Rs1, Register Rs2) {  \

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -104,7 +104,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, AvoidUnalignedAccesses, true,                                    \
           "Avoid generating unaligned memory accesses")                          \
   experimental(bool, UseRVV, false, "Use RVV instructions")                      \
-  experimental(bool, UseRVB, false, "Use RVB instructions")                      \
+  experimental(bool, UseZba, false, "Use Zba instructions")                      \
+  experimental(bool, UseZbb, false, "Use Zbb instructions")                      \
   experimental(bool, UseRVC, false, "Use RVC instructions")
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1426,7 +1426,7 @@ void MacroAssembler::store_sized_value(Address dst, Register src, size_t size_in
 // reverse bytes in halfword in lower 16 bits and sign-extend
 // Rd[15:0] = Rs[7:0] Rs[15:8] (sign-extend to 64 bits)
 void MacroAssembler::revb_h_h(Register Rd, Register Rs, Register tmp) {
-  if (UseRVB) {
+  if (UseZbb) {
     rev8(Rd, Rs);
     srai(Rd, Rd, 48);
     return;
@@ -1443,7 +1443,7 @@ void MacroAssembler::revb_h_h(Register Rd, Register Rs, Register tmp) {
 // reverse bytes in lower word and sign-extend
 // Rd[31:0] = Rs[7:0] Rs[15:8] Rs[23:16] Rs[31:24] (sign-extend to 64 bits)
 void MacroAssembler::revb_w_w(Register Rd, Register Rs, Register tmp1, Register tmp2) {
-  if (UseRVB) {
+  if (UseZbb) {
     rev8(Rd, Rs);
     srai(Rd, Rd, 32);
     return;
@@ -1460,7 +1460,7 @@ void MacroAssembler::revb_w_w(Register Rd, Register Rs, Register tmp1, Register 
 // reverse bytes in halfword in lower 16 bits and zero-extend
 // Rd[15:0] = Rs[7:0] Rs[15:8] (zero-extend to 64 bits)
 void MacroAssembler::revb_h_h_u(Register Rd, Register Rs, Register tmp) {
-  if (UseRVB) {
+  if (UseZbb) {
     rev8(Rd, Rs);
     srli(Rd, Rd, 48);
     return;
@@ -1477,11 +1477,11 @@ void MacroAssembler::revb_h_h_u(Register Rd, Register Rs, Register tmp) {
 // reverse bytes in halfwords in lower 32 bits and zero-extend
 // Rd[31:0] = Rs[23:16] Rs[31:24] Rs[7:0] Rs[15:8] (zero-extend to 64 bits)
 void MacroAssembler::revb_h_w_u(Register Rd, Register Rs, Register tmp1, Register tmp2) {
-  if (UseRVB) {
+  if (UseZbb) {
     rev8(Rd, Rs);
     rori(Rd, Rd, 32);
     roriw(Rd, Rd, 16);
-    zext_w(Rd, Rd);
+    zero_extend(Rd, Rd, 32);
     return;
   }
   assert_different_registers(Rs, tmp1, tmp2);
@@ -1510,16 +1510,16 @@ void MacroAssembler::revb_h_helper(Register Rd, Register Rs, Register tmp1, Regi
 // reverse bytes in each halfword
 // Rd[63:0] = Rs[55:48] Rs[63:56] Rs[39:32] Rs[47:40] Rs[23:16] Rs[31:24] Rs[7:0] Rs[15:8]
 void MacroAssembler::revb_h(Register Rd, Register Rs, Register tmp1, Register tmp2) {
-  if (UseRVB) {
+  if (UseZbb) {
     assert_different_registers(Rs, tmp1);
     assert_different_registers(Rd, tmp1);
     rev8(Rd, Rs);
-    zext_w(tmp1, Rd);
+    zero_extend(tmp1, Rd, 32);
     roriw(tmp1, tmp1, 16);
     slli(tmp1, tmp1, 32);
     srli(Rd, Rd, 32);
     roriw(Rd, Rd, 16);
-    zext_w(Rd, Rd);
+    zero_extend(Rd, Rd, 32);
     orr(Rd, Rd, tmp1);
     return;
   }
@@ -1534,7 +1534,7 @@ void MacroAssembler::revb_h(Register Rd, Register Rs, Register tmp1, Register tm
 // reverse bytes in each word
 // Rd[63:0] = Rs[39:32] Rs[47:40] Rs[55:48] Rs[63:56] Rs[7:0] Rs[15:8] Rs[23:16] Rs[31:24]
 void MacroAssembler::revb_w(Register Rd, Register Rs, Register tmp1, Register tmp2) {
-  if (UseRVB) {
+  if (UseZbb) {
     rev8(Rd, Rs);
     rori(Rd, Rd, 32);
     return;
@@ -1548,7 +1548,7 @@ void MacroAssembler::revb_w(Register Rd, Register Rs, Register tmp1, Register tm
 // reverse bytes in doubleword
 // Rd[63:0] = Rs[7:0] Rs[15:8] Rs[23:16] Rs[31:24] Rs[39:32] Rs[47,40] Rs[55,48] Rs[63:56]
 void MacroAssembler::revb(Register Rd, Register Rs, Register tmp1, Register tmp2) {
-  if (UseRVB) {
+  if (UseZbb) {
     rev8(Rd, Rs);
     return;
   }
@@ -1570,7 +1570,7 @@ void MacroAssembler::revb(Register Rd, Register Rs, Register tmp1, Register tmp2
 // rotate right with shift bits
 void MacroAssembler::ror_imm(Register dst, Register src, uint32_t shift, Register tmp)
 {
-  if (UseRVB) {
+  if (UseZbb) {
     rori(dst, src, shift);
     return;
   }
@@ -3708,7 +3708,7 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen, Register y, Regi
 // shift 16 bits once.
 void MacroAssembler::ctzc_bit(Register Rd, Register Rs, bool isLL, Register tmp1, Register tmp2)
 {
-  if (UseRVB) {
+  if (UseZbb) {
     assert_different_registers(Rd, Rs, tmp1);
     int step = isLL ? 8 : 16;
     ctz(Rd, Rs);
@@ -4050,7 +4050,7 @@ void MacroAssembler::zero_memory(Register addr, Register len, Register tmp) {
 // shift left by shamt and add
 // Rd = (Rs1 << shamt) + Rs2
 void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt) {
-  if (UseRVB) {
+  if (UseZba) {
     if (shamt == 1) {
       sh1add(Rd, Rs1, Rs2);
       return;
@@ -4072,14 +4072,14 @@ void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp
 }
 
 void MacroAssembler::zero_extend(Register dst, Register src, int bits) {
-  if (UseRVB) {
-    if (bits == 16) {
-      zext_h(dst, src);
-      return;
-    } else if (bits == 32) {
-      zext_w(dst, src);
-      return;
-    }
+  if (UseZba && bits == 32) {
+    zext_w(dst, src);
+    return;
+  }
+
+  if (UseZbb && bits == 16) {
+    zext_h(dst, src);
+    return;
   }
 
   if (bits == 8) {
@@ -4091,7 +4091,7 @@ void MacroAssembler::zero_extend(Register dst, Register src, int bits) {
 }
 
 void MacroAssembler::sign_extend(Register dst, Register src, int bits) {
-  if (UseRVB) {
+  if (UseZbb) {
     if (bits == 8) {
       sext_b(dst, src);
       return;

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1483,7 +1483,7 @@ const bool Matcher::match_rule_supported(int opcode) {
     case Op_CountLeadingZerosL:
     case Op_CountTrailingZerosI:
     case Op_CountTrailingZerosL:
-      return UseRVB;
+      return UseZbb;
   }
 
   return true; // Per default match rules are supported.

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -26,11 +26,11 @@
 // RISCV Bit-Manipulation Extension Architecture Description File
 
 // Convert oop into int for vectors alignment masking
-instruct convP2I_rvb(iRegINoSp dst, iRegP src) %{
-  predicate(UseRVB);
+instruct convP2I_b(iRegINoSp dst, iRegP src) %{
+  predicate(UseZba);
   match(Set dst (ConvL2I (CastP2X src)));
 
-  format %{ "zext.w  $dst, $src\t# ptr -> int @convP2I_rvb" %}
+  format %{ "zext.w  $dst, $src\t# ptr -> int @convP2I_b" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -41,11 +41,11 @@ instruct convP2I_rvb(iRegINoSp dst, iRegP src) %{
 %}
 
 // byte to int
-instruct convB2I_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_24 lshift, immI_24 rshift) %{
-  predicate(UseRVB);
+instruct convB2I_reg_reg_b(iRegINoSp dst, iRegIorL2I src, immI_24 lshift, immI_24 rshift) %{
+  predicate(UseZbb);
   match(Set dst (RShiftI (LShiftI src lshift) rshift));
 
-  format %{ "sext.b  $dst, $src\t# b2i, #@convB2I_reg_reg_rvb" %}
+  format %{ "sext.b  $dst, $src\t# b2i, #@convB2I_reg_reg_b" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -56,11 +56,11 @@ instruct convB2I_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_24 lshift, immI
 %}
 
 // int to short
-instruct convI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI_16 rshift) %{
-  predicate(UseRVB);
+instruct convI2S_reg_reg_b(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI_16 rshift) %{
+  predicate(UseZbb);
   match(Set dst (RShiftI (LShiftI src lshift) rshift));
 
-  format %{ "sext.h  $dst, $src\t# i2s, #@convI2S_reg_reg_rvb" %}
+  format %{ "sext.h  $dst, $src\t# i2s, #@convI2S_reg_reg_b" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -71,11 +71,11 @@ instruct convI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI
 %}
 
 // short to unsigned int
-instruct convS2UI_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %{
-  predicate(UseRVB);
+instruct convS2UI_reg_reg_b(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %{
+  predicate(UseZbb);
   match(Set dst (AndI src mask));
 
-  format %{ "zext.h  $dst, $src\t# s2ui, #@convS2UI_reg_reg_rvb" %}
+  format %{ "zext.h  $dst, $src\t# s2ui, #@convS2UI_reg_reg_b" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -86,11 +86,11 @@ instruct convS2UI_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %
 %}
 
 // int to unsigned long (zero extend)
-instruct convI2UL_reg_reg_rvb(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %{
-  predicate(UseRVB);
+instruct convI2UL_reg_reg_b(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %{
+  predicate(UseZba);
   match(Set dst (AndL (ConvI2L src) mask));
 
-  format %{ "zext.w  $dst, $src\t# i2ul, #@convI2UL_reg_reg_rvb" %}
+  format %{ "zext.w  $dst, $src\t# i2ul, #@convI2UL_reg_reg_b" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -101,12 +101,12 @@ instruct convI2UL_reg_reg_rvb(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %
 %}
 
 // BSWAP instructions
-instruct bytes_reverse_int_rvb(iRegINoSp dst, iRegIorL2I src) %{
-  predicate(UseRVB);
+instruct bytes_reverse_int_b(iRegINoSp dst, iRegIorL2I src) %{
+  predicate(UseZbb);
   match(Set dst (ReverseBytesI src));
 
   ins_cost(ALU_COST * 2);
-  format %{ "revb_w_w  $dst, $src\t#@bytes_reverse_int_rvb" %}
+  format %{ "revb_w_w  $dst, $src\t#@bytes_reverse_int_b" %}
 
   ins_encode %{
     __ revb_w_w(as_Register($dst$$reg), as_Register($src$$reg));
@@ -115,12 +115,12 @@ instruct bytes_reverse_int_rvb(iRegINoSp dst, iRegIorL2I src) %{
   ins_pipe(ialu_reg);
 %}
 
-instruct bytes_reverse_long_rvb(iRegLNoSp dst, iRegL src) %{
-  predicate(UseRVB);
+instruct bytes_reverse_long_b(iRegLNoSp dst, iRegL src) %{
+  predicate(UseZbb);
   match(Set dst (ReverseBytesL src));
 
   ins_cost(ALU_COST);
-  format %{ "rev8  $dst, $src\t#@bytes_reverse_long_rvb" %}
+  format %{ "rev8  $dst, $src\t#@bytes_reverse_long_b" %}
 
   ins_encode %{
     __ rev8(as_Register($dst$$reg), as_Register($src$$reg));
@@ -129,12 +129,12 @@ instruct bytes_reverse_long_rvb(iRegLNoSp dst, iRegL src) %{
   ins_pipe(ialu_reg);
 %}
 
-instruct bytes_reverse_unsigned_short_rvb(iRegINoSp dst, iRegIorL2I src) %{
-  predicate(UseRVB);
+instruct bytes_reverse_unsigned_short_b(iRegINoSp dst, iRegIorL2I src) %{
+  predicate(UseZbb);
   match(Set dst (ReverseBytesUS src));
 
   ins_cost(ALU_COST * 2);
-  format %{ "revb_h_h_u  $dst, $src\t#@bytes_reverse_unsigned_short_rvb" %}
+  format %{ "revb_h_h_u  $dst, $src\t#@bytes_reverse_unsigned_short_b" %}
 
   ins_encode %{
     __ revb_h_h_u(as_Register($dst$$reg), as_Register($src$$reg));
@@ -143,12 +143,12 @@ instruct bytes_reverse_unsigned_short_rvb(iRegINoSp dst, iRegIorL2I src) %{
   ins_pipe(ialu_reg);
 %}
 
-instruct bytes_reverse_short_rvb(iRegINoSp dst, iRegIorL2I src) %{
-  predicate(UseRVB);
+instruct bytes_reverse_short_b(iRegINoSp dst, iRegIorL2I src) %{
+  predicate(UseZbb);
   match(Set dst (ReverseBytesS src));
 
   ins_cost(ALU_COST * 2);
-  format %{ "revb_h_h  $dst, $src\t#@bytes_reverse_short_rvb" %}
+  format %{ "revb_h_h  $dst, $src\t#@bytes_reverse_short_b" %}
 
   ins_encode %{
     __ revb_h_h(as_Register($dst$$reg), as_Register($src$$reg));
@@ -158,12 +158,12 @@ instruct bytes_reverse_short_rvb(iRegINoSp dst, iRegIorL2I src) %{
 %}
 
 // Shift Add Pointer
-instruct shaddP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale imm) %{
-  predicate(UseRVB);
+instruct shaddP_reg_reg_b(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale imm) %{
+  predicate(UseZba);
   match(Set dst (AddP src1 (LShiftL src2 imm)));
 
   ins_cost(ALU_COST);
-  format %{ "shadd  $dst, $src2, $src1, $imm\t# ptr, #@shaddP_reg_reg_rvb" %}
+  format %{ "shadd  $dst, $src2, $src1, $imm\t# ptr, #@shaddP_reg_reg_b" %}
 
   ins_encode %{
     __ shadd(as_Register($dst$$reg),
@@ -176,12 +176,12 @@ instruct shaddP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale imm
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct shaddP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale imm) %{
-  predicate(UseRVB);
+instruct shaddP_reg_reg_ext_b(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale imm) %{
+  predicate(UseZba);
   match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
 
   ins_cost(ALU_COST);
-  format %{ "shadd  $dst, $src2, $src1, $imm\t# ptr, #@shaddP_reg_reg_ext_rvb" %}
+  format %{ "shadd  $dst, $src2, $src1, $imm\t# ptr, #@shaddP_reg_reg_ext_b" %}
 
   ins_encode %{
     __ shadd(as_Register($dst$$reg),
@@ -195,12 +195,12 @@ instruct shaddP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale
 %}
 
 // Shift Add Long
-instruct shaddL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale imm) %{
-  predicate(UseRVB);
+instruct shaddL_reg_reg_b(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale imm) %{
+  predicate(UseZba);
   match(Set dst (AddL src1 (LShiftL src2 imm)));
 
   ins_cost(ALU_COST);
-  format %{ "shadd  $dst, $src2, $src1, $imm\t#@shaddL_reg_reg_rvb" %}
+  format %{ "shadd  $dst, $src2, $src1, $imm\t#@shaddL_reg_reg_b" %}
 
   ins_encode %{
     __ shadd(as_Register($dst$$reg),
@@ -213,12 +213,12 @@ instruct shaddL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale imm
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct shaddL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale imm) %{
-  predicate(UseRVB);
+instruct shaddL_reg_reg_ext_b(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale imm) %{
+  predicate(UseZba);
   match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
 
   ins_cost(ALU_COST);
-  format %{ "shadd  $dst, $src2, $src1, $imm\t#@shaddL_reg_reg_ext_rvb" %}
+  format %{ "shadd  $dst, $src2, $src1, $imm\t#@shaddL_reg_reg_ext_b" %}
 
   ins_encode %{
     __ shadd(as_Register($dst$$reg),
@@ -232,12 +232,12 @@ instruct shaddL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale
 %}
 
 // Zeros Count instructions
-instruct countLeadingZerosI_rvb(iRegINoSp dst, iRegIorL2I src) %{
-  predicate(UseRVB);
+instruct countLeadingZerosI_b(iRegINoSp dst, iRegIorL2I src) %{
+  predicate(UseZbb);
   match(Set dst (CountLeadingZerosI src));
 
   ins_cost(ALU_COST);
-  format %{ "clzw  $dst, $src\t#@countLeadingZerosI_rvb" %}
+  format %{ "clzw  $dst, $src\t#@countLeadingZerosI_b" %}
 
   ins_encode %{
     __ clzw(as_Register($dst$$reg), as_Register($src$$reg));
@@ -246,12 +246,12 @@ instruct countLeadingZerosI_rvb(iRegINoSp dst, iRegIorL2I src) %{
   ins_pipe(ialu_reg);
 %}
 
-instruct countLeadingZerosL_rvb(iRegINoSp dst, iRegL src) %{
-  predicate(UseRVB);
+instruct countLeadingZerosL_b(iRegINoSp dst, iRegL src) %{
+  predicate(UseZbb);
   match(Set dst (CountLeadingZerosL src));
 
   ins_cost(ALU_COST);
-  format %{ "clz  $dst, $src\t#@countLeadingZerosL_rvb" %}
+  format %{ "clz  $dst, $src\t#@countLeadingZerosL_b" %}
 
   ins_encode %{
     __ clz(as_Register($dst$$reg), as_Register($src$$reg));
@@ -260,12 +260,12 @@ instruct countLeadingZerosL_rvb(iRegINoSp dst, iRegL src) %{
   ins_pipe(ialu_reg);
 %}
 
-instruct countTrailingZerosI_rvb(iRegINoSp dst, iRegIorL2I src) %{
-  predicate(UseRVB);
+instruct countTrailingZerosI_b(iRegINoSp dst, iRegIorL2I src) %{
+  predicate(UseZbb);
   match(Set dst (CountTrailingZerosI src));
 
   ins_cost(ALU_COST);
-  format %{ "ctzw  $dst, $src\t#@countTrailingZerosI_rvb" %}
+  format %{ "ctzw  $dst, $src\t#@countTrailingZerosI_b" %}
 
   ins_encode %{
     __ ctzw(as_Register($dst$$reg), as_Register($src$$reg));
@@ -274,12 +274,12 @@ instruct countTrailingZerosI_rvb(iRegINoSp dst, iRegIorL2I src) %{
   ins_pipe(ialu_reg);
 %}
 
-instruct countTrailingZerosL_rvb(iRegINoSp dst, iRegL src) %{
-  predicate(UseRVB);
+instruct countTrailingZerosL_b(iRegINoSp dst, iRegL src) %{
+  predicate(UseZbb);
   match(Set dst (CountTrailingZerosL src));
 
   ins_cost(ALU_COST);
-  format %{ "ctz  $dst, $src\t#@countTrailingZerosL_rvb" %}
+  format %{ "ctz  $dst, $src\t#@countTrailingZerosL_b" %}
 
   ins_encode %{
     __ ctz(as_Register($dst$$reg), as_Register($src$$reg));
@@ -289,12 +289,12 @@ instruct countTrailingZerosL_rvb(iRegINoSp dst, iRegL src) %{
 %}
 
 // Population Count instructions
-instruct popCountI_rvb(iRegINoSp dst, iRegIorL2I src) %{
+instruct popCountI_b(iRegINoSp dst, iRegIorL2I src) %{
   predicate(UsePopCountInstruction);
   match(Set dst (PopCountI src));
 
   ins_cost(ALU_COST);
-  format %{ "cpopw  $dst, $src\t#@popCountI_rvb" %}
+  format %{ "cpopw  $dst, $src\t#@popCountI_b" %}
 
   ins_encode %{
     __ cpopw(as_Register($dst$$reg), as_Register($src$$reg));
@@ -304,12 +304,12 @@ instruct popCountI_rvb(iRegINoSp dst, iRegIorL2I src) %{
 %}
 
 // Note: Long/bitCount(long) returns an int.
-instruct popCountL_rvb(iRegINoSp dst, iRegL src) %{
+instruct popCountL_b(iRegINoSp dst, iRegL src) %{
   predicate(UsePopCountInstruction);
   match(Set dst (PopCountL src));
 
   ins_cost(ALU_COST);
-  format %{ "cpop  $dst, $src\t#@popCountL_rvb" %}
+  format %{ "cpop  $dst, $src\t#@popCountL_b" %}
 
   ins_encode %{
     __ cpop(as_Register($dst$$reg), as_Register($src$$reg));
@@ -319,12 +319,12 @@ instruct popCountL_rvb(iRegINoSp dst, iRegL src) %{
 %}
 
 // Max and Min
-instruct minI_reg_rvb(iRegINoSp dst, iRegI src1, iRegI src2) %{
-  predicate(UseRVB);
+instruct minI_reg_b(iRegINoSp dst, iRegI src1, iRegI src2) %{
+  predicate(UseZbb);
   match(Set dst (MinI src1 src2));
 
   ins_cost(ALU_COST);
-  format %{ "min  $dst, $src1, $src2\t#@minI_reg_rvb" %}
+  format %{ "min  $dst, $src1, $src2\t#@minI_reg_b" %}
 
   ins_encode %{
     __ min(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
@@ -333,12 +333,12 @@ instruct minI_reg_rvb(iRegINoSp dst, iRegI src1, iRegI src2) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct maxI_reg_rvb(iRegINoSp dst, iRegI src1, iRegI src2) %{
-  predicate(UseRVB);
+instruct maxI_reg_b(iRegINoSp dst, iRegI src1, iRegI src2) %{
+  predicate(UseZbb);
   match(Set dst (MaxI src1 src2));
 
   ins_cost(ALU_COST);
-  format %{ "max  $dst, $src1, $src2\t#@maxI_reg_rvb" %}
+  format %{ "max  $dst, $src1, $src2\t#@maxI_reg_b" %}
 
   ins_encode %{
     __ max(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
@@ -348,14 +348,14 @@ instruct maxI_reg_rvb(iRegINoSp dst, iRegI src1, iRegI src2) %{
 %}
 
 // Abs
-instruct absI_reg_rvb(iRegINoSp dst, iRegI src) %{
-  predicate(UseRVB);
+instruct absI_reg_b(iRegINoSp dst, iRegI src) %{
+  predicate(UseZbb);
   match(Set dst (AbsI src));
 
   ins_cost(ALU_COST * 2);
   format %{
     "negw  t0, $src\n\t"
-    "max  $dst, $src, t0\t#@absI_reg_rvb"
+    "max  $dst, $src, t0\t#@absI_reg_b"
   %}
 
   ins_encode %{
@@ -366,14 +366,14 @@ instruct absI_reg_rvb(iRegINoSp dst, iRegI src) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct absL_reg_rvb(iRegLNoSp dst, iRegL src) %{
-  predicate(UseRVB);
+instruct absL_reg_b(iRegLNoSp dst, iRegL src) %{
+  predicate(UseZbb);
   match(Set dst (AbsL src));
 
   ins_cost(ALU_COST * 2);
   format %{
     "neg  t0, $src\n\t"
-    "max $dst, $src, t0\t#@absL_reg_rvb"
+    "max  $dst, $src, t0\t#@absL_reg_b"
   %}
 
   ins_encode %{
@@ -385,12 +385,12 @@ instruct absL_reg_rvb(iRegLNoSp dst, iRegL src) %{
 %}
 
 // And Not
-instruct andnI_reg_reg_rvb(iRegINoSp dst, iRegI src1, iRegI src2, immI_M1 m1) %{
-  predicate(UseRVB);
+instruct andnI_reg_reg_b(iRegINoSp dst, iRegI src1, iRegI src2, immI_M1 m1) %{
+  predicate(UseZbb);
   match(Set dst (AndI src1 (XorI src2 m1)));
 
   ins_cost(ALU_COST);
-  format %{ "andn  $dst, $src1, $src2\t#@andnI_reg_reg_rvb" %}
+  format %{ "andn  $dst, $src1, $src2\t#@andnI_reg_reg_b" %}
 
   ins_encode %{
     __ andn(as_Register($dst$$reg),
@@ -401,12 +401,12 @@ instruct andnI_reg_reg_rvb(iRegINoSp dst, iRegI src1, iRegI src2, immI_M1 m1) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct andnL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immL_M1 m1) %{
-  predicate(UseRVB);
+instruct andnL_reg_reg_b(iRegLNoSp dst, iRegL src1, iRegL src2, immL_M1 m1) %{
+  predicate(UseZbb);
   match(Set dst (AndL src1 (XorL src2 m1)));
 
   ins_cost(ALU_COST);
-  format %{ "andn  $dst, $src1, $src2\t#@andnL_reg_reg_rvb" %}
+  format %{ "andn  $dst, $src1, $src2\t#@andnL_reg_reg_b" %}
 
   ins_encode %{
     __ andn(as_Register($dst$$reg),
@@ -418,12 +418,12 @@ instruct andnL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immL_M1 m1) %{
 %}
 
 // Or Not
-instruct ornI_reg_reg_rvb(iRegINoSp dst, iRegI src1, iRegI src2, immI_M1 m1) %{
-  predicate(UseRVB);
+instruct ornI_reg_reg_b(iRegINoSp dst, iRegI src1, iRegI src2, immI_M1 m1) %{
+  predicate(UseZbb);
   match(Set dst (OrI src1 (XorI src2 m1)));
 
   ins_cost(ALU_COST);
-  format %{ "orn  $dst, $src1, $src2\t#@ornI_reg_reg_rvb" %}
+  format %{ "orn  $dst, $src1, $src2\t#@ornI_reg_reg_b" %}
 
   ins_encode %{
     __ orn(as_Register($dst$$reg),
@@ -434,12 +434,12 @@ instruct ornI_reg_reg_rvb(iRegINoSp dst, iRegI src1, iRegI src2, immI_M1 m1) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct ornL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immL_M1 m1) %{
-  predicate(UseRVB);
+instruct ornL_reg_reg_b(iRegLNoSp dst, iRegL src1, iRegL src2, immL_M1 m1) %{
+  predicate(UseZbb);
   match(Set dst (OrL src1 (XorL src2 m1)));
 
   ins_cost(ALU_COST);
-  format %{ "orn  $dst, $src1, $src2\t#@ornL_reg_reg_rvb" %}
+  format %{ "orn  $dst, $src1, $src2\t#@ornL_reg_reg_b" %}
 
   ins_encode %{
     __ orn(as_Register($dst$$reg),

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -102,11 +102,6 @@ void VM_Version::initialize() {
     }
   }
 
-  if (UseRVB && !(_features & CPU_B)) {
-    warning("RVB is not supported on this CPU");
-    FLAG_SET_DEFAULT(UseRVB, false);
-  }
-
   if (UseRVC && !(_features & CPU_C)) {
     warning("RVC is not supported on this CPU");
     FLAG_SET_DEFAULT(UseRVC, false);
@@ -116,7 +111,7 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(AvoidUnalignedAccesses, true);
   }
 
-  if (UseRVB) {
+  if (UseZbb) {
     if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
       FLAG_SET_DEFAULT(UsePopCountInstruction, true);
     }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -56,8 +56,7 @@ public:
     decl(F,            "f",            5)     \
     decl(D,            "d",            3)     \
     decl(C,            "c",            2)     \
-    decl(V,            "v",           21)     \
-    decl(B,            "b",            1)
+    decl(V,            "v",           21)
 
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1 << bit),
     CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -60,10 +60,6 @@
 #define HWCAP_ISA_V  (1 << ('V' - 'A'))
 #endif
 
-#ifndef HWCAP_ISA_B
-#define HWCAP_ISA_B  (1 << ('B' - 'A'))
-#endif
-
 #define read_csr(csr)                                           \
 ({                                                              \
         register unsigned long __v;                             \
@@ -90,7 +86,10 @@ void VM_Version::get_os_cpu_info() {
   STATIC_ASSERT(CPU_D == HWCAP_ISA_D);
   STATIC_ASSERT(CPU_C == HWCAP_ISA_C);
   STATIC_ASSERT(CPU_V == HWCAP_ISA_V);
-  STATIC_ASSERT(CPU_B == HWCAP_ISA_B);
+
+  // RISC-V has four bit-manipulation ISA-extensions: Zba/Zbb/Zbc/Zbs.
+  // Availability for those extensions could not be queried from HWCAP.
+  // TODO: Add proper detection for those extensions.
   _features = auxv & (
       HWCAP_ISA_I |
       HWCAP_ISA_M |
@@ -98,8 +97,7 @@ void VM_Version::get_os_cpu_info() {
       HWCAP_ISA_F |
       HWCAP_ISA_D |
       HWCAP_ISA_C |
-      HWCAP_ISA_V |
-      HWCAP_ISA_B);
+      HWCAP_ISA_V);
 
   if (FILE *f = fopen("/proc/cpuinfo", "r")) {
     char buf[512], *p;


### PR DESCRIPTION
Hi, The same issue[1] also exists in the riscv-port-jdk11u. According to the spec,  we need to break down UseRVB into two individual options UseZba and UseZbb to enable or disable Zba and Zbb respectively. 

Linux RISCV64 release hotspot/jdk tier1 tests are passed on QEMU with following options:
 - [x] +UseZba && +UseZbb
 - [x] +UseZba && -UseZbb
 - [x] -UseZba && +UseZbb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8283865](https://bugs.openjdk.org/browse/JDK-8283865): riscv: Break down -XX:+UseRVB into seperate options for each bitmanip extension (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/13.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/13.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/13#issuecomment-2016358084)