### PR TITLE
8328948: GHA: Restoring sysroot from cache skips the build after JDK-8326960

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -179,7 +179,7 @@ jobs:
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
-        if: steps.create-sysroot.outcome == 'success'
+        if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'
 
       - name: 'Build'
         id: build
@@ -187,4 +187,4 @@ jobs:
         with:
           make-target: 'hotspot ${{ inputs.make-arguments }}'
           platform: linux-${{ matrix.target-cpu }}
-        if: steps.create-sysroot.outcome == 'success'
+        if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'


### PR DESCRIPTION
Fixes a recent GHA regression. Applies cleanly.

- [x] GHA, first run passes cross-builds
- [x] GHA, second run passes cross-builds

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328948](https://bugs.openjdk.org/browse/JDK-8328948): GHA: Restoring sysroot from cache skips the build after JDK-8326960 (**Bug** - P1)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/15.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/15.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/15#issuecomment-2019208641)