### PR TITLE
8291893: riscv: remove fence.i used in user space

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -311,13 +311,6 @@ void Assembler::movptr(Register Rd, address addr) {
   addi(Rd, Rd, offset);
 }
 
-void Assembler::ifence() {
-  fence_i();
-  if (UseConservativeFence) {
-    fence(ir, ir);
-  }
-}
-
 #define INSN(NAME, NEG_INSN)                                                         \
   void Assembler::NAME(Register Rs, Register Rt, const address &dest) {              \
     NEG_INSN(Rt, Rs, dest);                                                          \

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -318,7 +318,6 @@ public:
   void movptr(Register Rd, address addr);
   void movptr_with_offset(Register Rd, address addr, int32_t &offset);
   void movptr(Register Rd, uintptr_t imm64);
-  void ifence();
   void j(const address &dest, Register temp = t0);
   void j(const Address &adr, Register temp = t0);
   void j(Label &l, Register temp = t0);
@@ -897,7 +896,6 @@ public:
     emit(insn);                                             \
   }
 
-  INSN(fence_i, 0b0001111, 0b001, 0b000000000000);
   INSN(ecall,   0b1110011, 0b000, 0b000000000000);
   INSN(_ebreak, 0b1110011, 0b000, 0b000000000001);
 

--- a/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
@@ -69,8 +69,8 @@ address CompiledStaticCall::emit_to_interp_stub(CodeBuffer &cbuf, address mark) 
 #undef __
 
 int CompiledStaticCall::to_interp_stub_size() {
-  // fence_i + fence* + (lui, addi, slli, addi, slli, addi) + (lui, addi, slli, addi, slli) + jalr
-  return NativeFenceI::instruction_size() + 12 * NativeInstruction::instruction_size;
+  // (lui, addi, slli, addi, slli, addi) + (lui, addi, slli, addi, slli) + jalr
+  return 12 * NativeInstruction::instruction_size;
 }
 
 int CompiledStaticCall::to_trampoline_stub_size() {
@@ -97,8 +97,7 @@ void CompiledDirectStaticCall::set_to_interpreted(const methodHandle& callee, ad
   }
 
   // Creation also verifies the object.
-  NativeMovConstReg* method_holder
-    = nativeMovConstReg_at(stub + NativeFenceI::instruction_size());
+  NativeMovConstReg* method_holder = nativeMovConstReg_at(stub);
 #ifndef PRODUCT
   NativeGeneralJump* jump = nativeGeneralJump_at(method_holder->next_instruction_address());
 
@@ -123,8 +122,7 @@ void CompiledDirectStaticCall::set_stub_to_clean(static_stub_Relocation* static_
   address stub = static_stub->addr();
   assert(stub != NULL, "stub not found");
   // Creation also verifies the object.
-  NativeMovConstReg* method_holder
-    = nativeMovConstReg_at(stub + NativeFenceI::instruction_size());
+  NativeMovConstReg* method_holder = nativeMovConstReg_at(stub);
   method_holder->set_data(0);
 }
 
@@ -141,8 +139,7 @@ void CompiledDirectStaticCall::verify() {
   address stub = find_stub(false /* is_aot */);
   assert(stub != NULL, "no stub found for static call");
   // Creation also verifies the object.
-  NativeMovConstReg* method_holder
-    = nativeMovConstReg_at(stub + NativeFenceI::instruction_size());
+  NativeMovConstReg* method_holder = nativeMovConstReg_at(stub);
   NativeJump* jump = nativeJump_at(method_holder->next_instruction_address());
 
   // Verify state.

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -99,8 +99,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, TraceTraps, false, "Trace all traps the signal handler")         \
   /* For now we're going to be safe and add the I/O bits to userspace fences. */ \
   product(bool, UseConservativeFence, true,                                      \
-          "Extend i for r and o for w in the pred/succ flags of fence;"          \
-          "Extend fence.i to fence.i + fence.")                                  \
+          "Extend i for r and o for w in the pred/succ flags of fence")          \
   product(bool, AvoidUnalignedAccesses, true,                                    \
           "Avoid generating unaligned memory accesses")                          \
   experimental(bool, UseRVV, false, "Use RVV instructions")                      \

--- a/src/hotspot/cpu/riscv/icache_riscv.cpp
+++ b/src/hotspot/cpu/riscv/icache_riscv.cpp
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2023, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +26,8 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.hpp"
+#include "riscv_flush_icache.hpp"
+#include "runtime/java.hpp"
 #include "runtime/icache.hpp"
 
 #define __ _masm->
@@ -33,16 +36,22 @@ static int icache_flush(address addr, int lines, int magic) {
   // To make a store to instruction memory visible to all RISC-V harts,
   // the writing hart has to execute a data FENCE before requesting that
   // all remote RISC-V harts execute a FENCE.I.
-  //
-  // No sush assurance is defined at the interface level of the builtin
-  // method, and so we should make sure it works.
+
+  // We need to make sure stores happens before the I/D cache synchronization.
   __asm__ volatile("fence rw, rw" : : : "memory");
 
-  __builtin___clear_cache(addr, addr + (lines << ICache::log2_line_size));
+  RiscvFlushIcache::flush((uintptr_t)addr, ((uintptr_t)lines) << ICache::log2_line_size);
+
   return magic;
 }
 
 void ICacheStubGenerator::generate_icache_flush(ICache::flush_icache_stub_t* flush_icache_stub) {
+  // Only riscv_flush_icache is supported as I-cache synchronization.
+  // We must make sure the VM can execute such without error.
+  if (!RiscvFlushIcache::test()) {
+    vm_exit_during_initialization("Unable to synchronize I-cache");
+  }
+
   address start = (address)icache_flush;
   *flush_icache_stub = (ICache::flush_icache_stub_t)start;
 

--- a/src/hotspot/cpu/riscv/icache_riscv.cpp
+++ b/src/hotspot/cpu/riscv/icache_riscv.cpp
@@ -30,7 +30,15 @@
 #define __ _masm->
 
 static int icache_flush(address addr, int lines, int magic) {
-  os::icache_flush((long int) addr, (long int) (addr + (lines << ICache::log2_line_size)));
+  // To make a store to instruction memory visible to all RISC-V harts,
+  // the writing hart has to execute a data FENCE before requesting that
+  // all remote RISC-V harts execute a FENCE.I.
+  //
+  // No sush assurance is defined at the interface level of the builtin
+  // method, and so we should make sure it works.
+  __asm__ volatile("fence rw, rw" : : : "memory");
+
+  __builtin___clear_cache(addr, addr + (lines << ICache::log2_line_size));
   return magic;
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -574,7 +574,6 @@ void MacroAssembler::emit_static_call_stub() {
   // CompiledDirectStaticCall::set_to_interpreted knows the
   // exact layout of this stub.
 
-  ifence();
   mov_metadata(xmethod, (Metadata*)NULL);
 
   // Jump to the entry point of the i2c stub.
@@ -4135,10 +4134,6 @@ void MacroAssembler::cmp_l2i(Register dst, Register src1, Register src2, Registe
   // dst = -1 if lt; else if eq , dst = 0
   neg(dst, dst);
   bind(done);
-}
-
-void MacroAssembler::safepoint_ifence() {
-  ifence();
 }
 
 #ifdef COMPILER2

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -71,9 +71,6 @@ class MacroAssembler: public Assembler {
     atomic_incw(tmp1, tmp2);
   }
 
-  // Place a fence.i after code may have been modified due to a safepoint.
-  void safepoint_ifence();
-
   // Alignment
   void align(int modulus, int extra_offset = 0);
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -41,7 +41,6 @@
 // - - NativeIllegalInstruction
 // - - NativeCallTrampolineStub
 // - - NativeMembar
-// - - NativeFenceI
 
 // The base class for different kinds of native instruction abstractions.
 // Provides the primitive operations to manipulate code relative to this.
@@ -552,13 +551,5 @@ inline NativeMembar *NativeMembar_at(address addr) {
   assert(nativeInstruction_at(addr)->is_membar(), "no membar found");
   return (NativeMembar*)addr;
 }
-
-class NativeFenceI : public NativeInstruction {
-public:
-  static inline int instruction_size() {
-    // 2 for fence.i + fence
-    return (UseConservativeFence ? 2 : 1) * NativeInstruction::instruction_size;
-  }
-};
 
 #endif // CPU_RISCV_NATIVEINST_RISCV_HPP

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -331,10 +331,6 @@ static void patch_callers_callsite(MacroAssembler *masm) {
   __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::fixup_callers_callsite)), offset);
   __ jalr(x1, t0, offset);
 
-  // Explicit fence.i required because fixup_callers_callsite may change the code
-  // stream.
-  __ safepoint_ifence();
-
   __ pop_CPU_state();
   // restore sp
   __ leave();

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.hpp
@@ -37,23 +37,4 @@
     *(jlong *) dst = *(const jlong *) src;
   }
 
-  // SYSCALL_RISCV_FLUSH_ICACHE is used to flush instruction cache. The "fence.i" instruction
-  // only work on the current hart, so kernel provides the icache flush syscall to flush icache
-  // on each hart. You can pass a flag to determine a global or local icache flush.
-  static void icache_flush(long int start, long int end)
-  {
-    const int SYSCALL_RISCV_FLUSH_ICACHE = 259;
-    register long int __a7 asm ("a7") = SYSCALL_RISCV_FLUSH_ICACHE;
-    register long int __a0 asm ("a0") = start;
-    register long int __a1 asm ("a1") = end;
-    // the flush can be applied to either all threads or only the current.
-    // 0 means a global icache flush, and the icache flush will be applied
-    // to other harts concurrently executing.
-    register long int __a2 asm ("a2") = 0;
-    __asm__ volatile ("ecall\n\t"
-                      : "+r" (__a0)
-                      : "r" (__a0), "r" (__a1), "r" (__a2), "r" (__a7)
-                      : "memory");
-  }
-
 #endif // OS_CPU_LINUX_RISCV_VM_OS_LINUX_RISCV_HPP

--- a/src/hotspot/os_cpu/linux_riscv/riscv_flush_icache.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_flush_icache.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Rivos Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "logging/log.hpp"
+#include "riscv_flush_icache.hpp"
+#include "runtime/os.hpp"
+#include "runtime/vm_version.hpp"
+#include "utilities/debug.hpp"
+
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define check_with_errno(check_type, cond, msg)                             \
+  do {                                                                      \
+    int err = errno;                                                        \
+    check_type(cond, "%s; error='%s' (errno=%s)", msg, os::strerror(err),   \
+               os::errno_name(err));                                        \
+} while (false)
+
+#define assert_with_errno(cond, msg)    check_with_errno(assert, cond, msg)
+#define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
+
+#ifndef NR_riscv_flush_icache
+#ifndef NR_arch_specific_syscall
+#define NR_arch_specific_syscall 244
+#endif
+#define NR_riscv_flush_icache (NR_arch_specific_syscall + 15)
+#endif
+
+#define SYS_RISCV_FLUSH_ICACHE_LOCAL 1UL
+#define SYS_RISCV_FLUSH_ICACHE_ALL   0UL
+
+static long sys_flush_icache(uintptr_t start, uintptr_t end , uintptr_t flags) {
+  return syscall(NR_riscv_flush_icache, start, end, flags);
+}
+
+bool RiscvFlushIcache::test() {
+  ATTRIBUTE_ALIGNED(64) char memory[64];
+  long ret = sys_flush_icache((uintptr_t)&memory[0],
+                              (uintptr_t)&memory[sizeof(memory) - 1],
+                              SYS_RISCV_FLUSH_ICACHE_ALL);
+  if (ret == 0) {
+    return true;
+  }
+  int err = errno;                                                        \
+  log_error(os)("Syscall: RISCV_FLUSH_ICACHE not available; error='%s' (errno=%s)",
+                os::strerror(err), os::errno_name(err));
+  return false;
+}
+
+void RiscvFlushIcache::flush(uintptr_t start, uintptr_t end) {
+  long ret = sys_flush_icache(start, end, SYS_RISCV_FLUSH_ICACHE_ALL);
+  guarantee_with_errno(ret == 0, "riscv_flush_icache failed");
+}

--- a/src/hotspot/os_cpu/linux_riscv/riscv_flush_icache.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_flush_icache.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Rivos Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef OS_LINUX_RISCV_FLUSH_ICACHE_LINUX_HPP
+#define OS_LINUX_RISCV_FLUSH_ICACHE_LINUX_HPP
+
+#include "runtime/vm_version.hpp"
+#include "utilities/growableArray.hpp"
+
+class RiscvFlushIcache: public AllStatic {
+ public:
+  static bool test();
+  static void flush(uintptr_t start, uintptr_t end);
+};
+
+#endif // OS_LINUX_RISCV_FLUSH_ICACHE_LINUX_HPP

--- a/src/hotspot/os_cpu/linux_riscv/riscv_flush_icache.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_flush_icache.hpp
@@ -26,6 +26,7 @@
 #ifndef OS_LINUX_RISCV_FLUSH_ICACHE_LINUX_HPP
 #define OS_LINUX_RISCV_FLUSH_ICACHE_LINUX_HPP
 
+#include "memory/allocation.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/growableArray.hpp"
 


### PR DESCRIPTION
Please help review this backport to riscv-port-jdk11u.
Backport of [JDK-8291893](https://bugs.openjdk.org/browse/JDK-8291893)

In addition to the backport [8291947](https://bugs.openjdk.org/browse/JDK-8291947), [8310656](https://bugs.openjdk.org/browse/JDK-8310656) to align and minimize the difference with 17u upstream.

Testing:

- [x] Run tier1-3 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8291893](https://bugs.openjdk.org/browse/JDK-8291893): riscv: remove fence.i used in user space (**Enhancement** - P4)
 * [JDK-8291947](https://bugs.openjdk.org/browse/JDK-8291947): riscv: fail to build after JDK-8290840 (**Bug** - P3)
 * [JDK-8310656](https://bugs.openjdk.org/browse/JDK-8310656): RISC-V: __builtin___clear_cache can fail silently. (**Bug** - P2)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/16.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/16#issuecomment-2022081925)