### PR TITLE
8297697: RISC-V: Add support for SATP mode detection

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -33,10 +33,16 @@
 #include OS_HEADER_INLINE(os)
 
 const char* VM_Version::_uarch = "";
+const char* VM_Version::_vm_mode = "";
 uint32_t VM_Version::_initial_vector_length = 0;
 
 void VM_Version::initialize() {
   get_os_cpu_info();
+
+  // check if satp.mode is supported, currently supports up to SV48(RV64)
+  if (get_satp_mode() > VM_SV48) {
+    vm_exit_during_initialization(err_msg("Unsupported satp mode: %s", _vm_mode));
+  }
 
   if (FLAG_IS_DEFAULT(UseFMA)) {
     FLAG_SET_DEFAULT(UseFMA, true);

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -41,7 +41,9 @@ void VM_Version::initialize() {
 
   // check if satp.mode is supported, currently supports up to SV48(RV64)
   if (get_satp_mode() > VM_SV48) {
-    vm_exit_during_initialization(err_msg("Unsupported satp mode: %s", _vm_mode));
+    vm_exit_during_initialization(
+      err_msg("Unsupported satp mode: %s. Only satp modes up to sv48 are supported for now.",
+              _vm_mode));
   }
 
   if (FLAG_IS_DEFAULT(UseFMA)) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -38,11 +38,22 @@ private:
   static void c2_initialize();
 #endif // COMPILER2
 
+// VM modes (satp.mode) privileged ISA 1.10
+enum VM_MODE {
+  VM_MBARE = 0,
+  VM_SV39  = 8,
+  VM_SV48  = 9,
+  VM_SV57  = 10,
+  VM_SV64  = 11
+};
+
 protected:
   static const char* _uarch;
+  static const char* _vm_mode;
   static uint32_t _initial_vector_length;
   static void get_os_cpu_info();
   static uint32_t get_current_vector_length();
+  static VM_MODE get_satp_mode();
 
 public:
   // Initialization

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -75,6 +75,20 @@ uint32_t VM_Version::get_current_vector_length() {
   return (uint32_t)read_csr(CSR_VLENB);
 }
 
+VM_Version::VM_MODE VM_Version::get_satp_mode() {
+  if (!strcmp(_vm_mode, "sv39")) {
+    return VM_SV39;
+  } else if (!strcmp(_vm_mode, "sv48")) {
+    return VM_SV48;
+  } else if (!strcmp(_vm_mode, "sv57")) {
+    return VM_SV57;
+  } else if (!strcmp(_vm_mode, "sv64")) {
+    return VM_SV64;
+  } else {
+    return VM_MBARE;
+  }
+}
+
 void VM_Version::get_os_cpu_info() {
 
   uint64_t auxv = getauxval(AT_HWCAP);
@@ -103,7 +117,14 @@ void VM_Version::get_os_cpu_info() {
     char buf[512], *p;
     while (fgets(buf, sizeof (buf), f) != NULL) {
       if ((p = strchr(buf, ':')) != NULL) {
-        if (strncmp(buf, "uarch", sizeof "uarch" - 1) == 0) {
+        if (strncmp(buf, "mmu", sizeof "mmu" - 1) == 0) {
+          if (_vm_mode[0] != '\0') {
+            continue;
+          }
+          char* vm_mode = os::strdup(p + 2);
+          vm_mode[strcspn(vm_mode, "\n")] = '\0';
+          _vm_mode = vm_mode;
+        } else if (strncmp(buf, "uarch", sizeof "uarch" - 1) == 0) {
           char* uarch = os::strdup(p + 2);
           uarch[strcspn(uarch, "\n")] = '\0';
           _uarch = uarch;


### PR DESCRIPTION
Hi,
Please review this backport to riscv-port-jdk11u.
Backport of [JDK-8297697](https://bugs.openjdk.org/browse/JDK-8297697), and [JDK-8301067](https://bugs.openjdk.org/browse/JDK-8301067). JDK-8301067 only modifies the log description information introduced by JDK-8297697.

After this patch, If it is an unsupported satp.mode , the message will be as follows:
```
root@qemuriscv64:~/jdk/bin# ./java -version
Error occurred during initialization of VM
Unsupported satp mode: sv57

root@qemuriscv64:~/jdk/bin# cat /proc/cpuinfo
processor       : 0
hart            : 0
isa             : rv64imafdch_zicbom_zicboz_zicntr_zicsr_zifencei_zihintpause_zihpm_zba_zbb_zbs_sstc
mmu             : sv57
mvendorid       : 0x0
marchid         : 0x0
mimpid          : 0x0
```

Testing:

- [ ] Run tier1 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8297697](https://bugs.openjdk.org/browse/JDK-8297697): RISC-V: Add support for SATP mode detection (**Enhancement** - P4)
 * [JDK-8301067](https://bugs.openjdk.org/browse/JDK-8301067): RISC-V: better error message when reporting unsupported satp modes (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [856643f1](https://git.openjdk.org/riscv-port-jdk11u/pull/19/files/856643f195e0c90ffdb28405c8fb690ff012647f)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/19.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/19.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/19#issuecomment-2043278637)