### PR TITLE
8297715: RISC-V: C2: Use single-bit instructions from the Zbs extension

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1943,7 +1943,7 @@ enum Nf {
 
 // ====================================
 // RISC-V Bit-Manipulation Extension
-// Currently only support Zba and Zbb.
+// Currently only support Zba, Zbb and Zbs bitmanip extensions.
 // ====================================
 #define INSN(NAME, op, funct3, funct7)                  \
   void NAME(Register Rd, Register Rs1, Register Rs2) {  \
@@ -2018,6 +2018,7 @@ enum Nf {
 
   INSN(rori,    0b0010011, 0b101, 0b011000);
   INSN(slli_uw, 0b0011011, 0b001, 0b000010);
+  INSN(bexti,   0b0010011, 0b101, 0b010010);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -105,6 +105,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   experimental(bool, UseRVV, false, "Use RVV instructions")                      \
   experimental(bool, UseZba, false, "Use Zba instructions")                      \
   experimental(bool, UseZbb, false, "Use Zbb instructions")                      \
+  experimental(bool, UseZbs, false, "Use Zbs instructions")                      \
   experimental(bool, UseRVC, false, "Use RVC instructions")
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2682,6 +2682,14 @@ operand immI_16bits()
   interface(CONST_INTER);
 %}
 
+operand immIpowerOf2() %{
+  predicate(is_power_of_2((juint)(n->get_int())));
+  match(ConI);
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 // Long Immediate: low 32-bit mask
 operand immL_32bits()
 %{

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -448,4 +448,19 @@ instruct ornL_reg_reg_b(iRegLNoSp dst, iRegL src1, iRegL src2, immL_M1 m1) %{
   %}
 
   ins_pipe(ialu_reg_reg);
+
+%}
+
+// AndI 0b0..010..0 + ConvI2B
+instruct convI2Bool_andI_reg_immIpowerOf2(iRegINoSp dst, iRegIorL2I src, immIpowerOf2 mask) %{
+  predicate(UseZbs);
+  match(Set dst (Conv2B (AndI src mask)));
+  ins_cost(ALU_COST);
+
+  format %{ "bexti  $dst, $src, $mask\t#@convI2Bool_andI_reg_immIpowerOf2" %}
+  ins_encode %{
+    __ bexti($dst$$Register, $src$$Register, exact_log2((juint)($mask$$constant)));
+  %}
+
+  ins_pipe(ialu_reg_reg);
 %}


### PR DESCRIPTION
Hi,
Please help review this backport to riscv-port-jdk11u.
Backport of [JDK-8297715](https://bugs.openjdk.org/browse/JDK-8297715).
The original patch cannot be directly applied because of  we use `experimental(bool, UseZbs, false, "Use Zbs instructions")` in riscv-port-jdk11u instead of OpenJDK higher version`product(bool, UseZbs, false, EXPERIMENTAL, "Use Zbs instructions")`

The effect is that we could then optimize C2 JIT code for methods like (print with case xml.validation in SPECjvm2008) on qemu system with `-XX:+UnlockExperimentalVMOptions -XX:+UseZbs`:
Before:
```
03c   	lhu  R28, [R11, #12]	# short, #@loadUS ! Field: com/sun/org/apache/xerces/internal/dom/NodeImpl.flags
040 + 	andi  R7, R28, #2	#@andI_reg_imm
044 + 	snez  R10, R7	#@convI2Bool
048   	# pop frame 32
```

After:
```
03c   	lhu  R28, [R11, #12]	# short, #@loadUS ! Field: com/sun/org/apache/xerces/internal/dom/NodeImpl.flags
040 + 	bexti  R10, R28, #2	#@convI2Bool_andI_reg_immIpowerOf2
044   	# pop frame 32
```

### Testing
- [x] Run tier1 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297715](https://bugs.openjdk.org/browse/JDK-8297715): RISC-V: C2: Use single-bit instructions from the Zbs extension (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/21.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/21.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/21#issuecomment-2046827920)