### PR TITLE
8294087: RISC-V: RVC: Fix a potential alignment issue and add more alignment assertions for the patchable calls/nops

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1357,7 +1357,7 @@ void LIR_Assembler::align_call(LIR_Code code) {
   // With RVC a call instruction may get 2-byte aligned.
   // The address of the call instruction needs to be 4-byte aligned to
   // ensure that it does not span a cache line so that it can be patched.
-  __ align(4);
+  __ align(NativeInstruction::instruction_size);
 }
 
 void LIR_Assembler::call(LIR_OpJavaCall* op, relocInfo::relocType rtype) {
@@ -1385,7 +1385,7 @@ void LIR_Assembler::vtable_call(LIR_OpJavaCall* op) {
 
 void LIR_Assembler::emit_static_call_stub() {
   address call_pc = __ pc();
-  assert((__ offset() % 4) == 0, "bad alignment");
+  MacroAssembler::assert_alignment(call_pc);
   address stub = __ start_a_stub(call_stub_size());
   if (stub == NULL) {
     bailout("static call stub overflow");

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -336,6 +336,7 @@ void C1_MacroAssembler::remove_frame(int framesize) {
 
 
 void C1_MacroAssembler::verified_entry() {
+  assert_alignment(pc());
 }
 
 void C1_MacroAssembler::load_parameter(int offset_in_words, Register reg) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3044,6 +3044,11 @@ address MacroAssembler::trampoline_call(Address entry, CodeBuffer* cbuf) {
   }
 
   if (cbuf != NULL) { cbuf->set_insts_mark(); }
+#ifdef ASSERT
+  if (entry.rspec().type() != relocInfo::runtime_call_type) {
+    assert_alignment(pc());
+  }
+#endif
   relocate(entry.rspec());
   if (!far_branches()) {
     jal(entry.target());

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -29,6 +29,7 @@
 
 #include "asm/assembler.hpp"
 #include "metaprogramming/enableIf.hpp"
+#include "nativeInst_riscv.hpp"
 
 // MacroAssembler extends Assembler by frequently used macros.
 //
@@ -73,6 +74,9 @@ class MacroAssembler: public Assembler {
 
   // Alignment
   void align(int modulus, int extra_offset = 0);
+  static inline void assert_alignment(address pc, int alignment = NativeInstruction::instruction_size) {
+    assert(is_aligned(pc, alignment), "bad alignment");
+  }
 
   // Stack frame creation/removal
   // Note that SP must be updated to the right place before saving/restoring RA and FP

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -264,6 +264,13 @@ void NativeJump::verify() { }
 
 
 void NativeJump::check_verified_entry_alignment(address entry, address verified_entry) {
+  // Patching to not_entrant can happen while activations of the method are
+  // in use. The patching in that instance must happen only when certain
+  // alignment restrictions are true. These guarantees check those
+  // conditions.
+
+  // Must be 4 bytes aligned
+  MacroAssembler::assert_alignment(verified_entry);
 }
 
 
@@ -342,6 +349,8 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
   assert(nativeInstruction_at(verified_entry)->is_jump_or_nop() ||
          nativeInstruction_at(verified_entry)->is_sigill_zombie_not_entrant(),
          "riscv cannot replace non-jump with jump");
+
+  check_verified_entry_alignment(entry, verified_entry);
 
   // Patch this nmethod atomically.
   if (Assembler::reachable_from_branch_at(verified_entry, dest)) {

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1063,6 +1063,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
+  MacroAssembler::assert_alignment(__ pc());
   __ nop();
 
   assert_cond(C != NULL);
@@ -1410,6 +1411,10 @@ void MachUEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
   __ cmp_klass(j_rarg0, t1, t0, skip);
   __ far_jump(RuntimeAddress(SharedRuntime::get_ic_miss_stub()));
   __ bind(skip);
+
+  // These NOPs are critical so that verified entry point is properly
+  // 4 bytes aligned for patching by NativeJump::patch_verified_entry()
+  __ align(NativeInstruction::instruction_size);
 }
 
 uint MachUEPNode::size(PhaseRegAlloc* ra_) const

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1094,6 +1094,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
+    MacroAssembler::assert_alignment(__ pc());
     __ nop();
     gen_special_dispatch(masm,
                          method,
@@ -1245,6 +1246,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
+  MacroAssembler::assert_alignment(__ pc());
   __ nop();
 
   // Generate stack overflow check


### PR DESCRIPTION
Hi,
Please help review this backport to riscv-port-jdk11u.
Backport of [JDK-8294087](https://bugs.openjdk.org/browse/JDK-8294087).
The original patch cannot be directly applied because of riscv-port-jdk11u do not have `emit_entry_barrier_stub ` C2CodeStub and no [JDK-8216557.](https://bugs.openjdk.org/browse/JDK-8216557.)

### Testing
- [x] Run tier1-tier3 tests on SOPHON SG2042 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294087](https://bugs.openjdk.org/browse/JDK-8294087): RISC-V: RVC: Fix a potential alignment issue and add more alignment assertions for the patchable calls/nops (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/22.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/22.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/22#issuecomment-2063249041)