### PR TITLE
8339548: GHA: RISC-V: Use Debian snapshot archive for bootstrap

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -84,7 +84,7 @@ jobs:
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
-            debian-repository: https://httpredir.debian.org/debian/
+            debian-repository: https://snapshot.debian.org/archive/debian/20240228T034848Z/
             debian-version: sid
             tolerate-sysroot-errors: true
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9e0ccb8b](https://github.com/openjdk/jdk/commit/9e0ccb8bbd01ffbac466288977a770dd09e357af) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fei Yang on 6 Sep 2024 and was reviewed by Aleksey Shipilev and Erik Joelsson.

Thanks!

Testing:

 - [x] GHA linux-cross-build job

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339548](https://bugs.openjdk.org/browse/JDK-8339548): GHA: RISC-V: Use Debian snapshot archive for bootstrap (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/28.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/28.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/28#issuecomment-2339406253)