### PR TITLE
8287552: riscv: Fix comment typo in li64

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -245,7 +245,7 @@ void Assembler::wrap_label(Register Rt, Label &L, jal_jalr_insn insn) {
 }
 
 void Assembler::movptr_with_offset(Register Rd, address addr, int32_t &offset) {
-  uintptr_t imm64 = (uintptr_t)addr;
+  int64_t imm64 = (int64_t)addr;
 #ifndef PRODUCT
   {
     char buffer[64];
@@ -253,10 +253,10 @@ void Assembler::movptr_with_offset(Register Rd, address addr, int32_t &offset) {
     block_comment(buffer);
   }
 #endif
-  assert(is_unsigned_imm_in_range(imm64, 47, 0) || (imm64 == (uintptr_t)-1),
+  assert(is_unsigned_imm_in_range(imm64, 47, 0) || (imm64 == (int64_t)-1),
          "bit 47 overflows in address constant");
   // Load upper 31 bits
-  int32_t imm = imm64 >> 17;
+  int64_t imm = imm64 >> 17;
   int64_t upper = imm, lower = imm;
   lower = (lower << 52) >> 52;
   upper -= lower;


### PR DESCRIPTION
Please review this backport to riscv-port-jdk11u.
Backport of [JDK-8287552](https://bugs.openjdk.java.net/browse/JDK-8287552). Applies not cleanly because [JDK-8339248](https://bugs.openjdk.org/browse/JDK-8339248) remove li64 macro assembler routine and related code. 
So this patch only unifies the immediate type in movptr_with_offset to int64_t.

Testing:

- Tier1 passed without new failure on lp4a(release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287552](https://bugs.openjdk.org/browse/JDK-8287552): riscv: Fix comment typo in li64 (**Bug** - P5)


### Reviewers
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/29.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/29.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/29#issuecomment-2342564411)