### PR TITLE
8290137: riscv: small refactoring for add_memory_int32/64

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -50,7 +50,7 @@ void Assembler::add(Register Rd, Register Rn, int64_t increment, Register temp) 
   }
 }
 
-void Assembler::addw(Register Rd, Register Rn, int64_t increment, Register temp) {
+void Assembler::addw(Register Rd, Register Rn, int32_t increment, Register temp) {
   if (is_imm_in_range(increment, 12, 0)) {
     addiw(Rd, Rn, increment);
   } else {
@@ -70,7 +70,7 @@ void Assembler::sub(Register Rd, Register Rn, int64_t decrement, Register temp) 
   }
 }
 
-void Assembler::subw(Register Rd, Register Rn, int64_t decrement, Register temp) {
+void Assembler::subw(Register Rd, Register Rn, int32_t decrement, Register temp) {
   if (is_imm_in_range(-decrement, 12, 0)) {
     addiw(Rd, Rn, -decrement);
   } else {

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -3014,11 +3014,12 @@ public:
   void wrap_label(Register r, Label &L, Register t, load_insn_by_temp insn);
   void wrap_label(Register r, Label &L, jal_jalr_insn insn);
 
-  // calculate pseudoinstruction
+  // Computational pseudo instructions
   void add(Register Rd, Register Rn, int64_t increment, Register temp = t0);
-  void addw(Register Rd, Register Rn, int64_t increment, Register temp = t0);
+  void addw(Register Rd, Register Rn, int32_t increment, Register temp = t0);
+
   void sub(Register Rd, Register Rn, int64_t decrement, Register temp = t0);
-  void subw(Register Rd, Register Rn, int64_t decrement, Register temp = t0);
+  void subw(Register Rd, Register Rn, int32_t decrement, Register temp = t0);
 
   // RVB pseudo instructions
   // zero extend word

--- a/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
@@ -329,7 +329,7 @@ void ArrayCopyStub::emit_code(LIR_Assembler* ce) {
 #ifndef PRODUCT
   if (PrintC1Statistics) {
     __ la(t1, ExternalAddress((address)&Runtime1::_arraycopy_slowcase_cnt));
-    __ add_memory_int32(Address(t1), 1);
+    __ incrementw(Address(t1));
   }
 #endif
 

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_arraycopy_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_arraycopy_riscv.cpp
@@ -57,7 +57,7 @@ void LIR_Assembler::generic_arraycopy(Register src, Register src_pos, Register l
   __ mv(c_rarg4, j_rarg4);
 #ifndef PRODUCT
   if (PrintC1Statistics) {
-    __ add_memory_int32(ExternalAddress((address)&Runtime1::_generic_arraycopystub_cnt), 1);
+    __ incrementw(ExternalAddress((address)&Runtime1::_generic_arraycopystub_cnt));
   }
 #endif
   __ far_call(RuntimeAddress(copyfunc_addr));
@@ -164,7 +164,7 @@ void LIR_Assembler::arraycopy_checkcast(Register src, Register src_pos, Register
   if (PrintC1Statistics) {
     Label failed;
     __ bnez(x10, failed);
-    __ add_memory_int32(ExternalAddress((address)&Runtime1::_arraycopy_checkcast_cnt), 1);
+    __ incrementw(ExternalAddress((address)&Runtime1::_arraycopy_checkcast_cnt));
     __ bind(failed);
   }
 #endif
@@ -173,7 +173,7 @@ void LIR_Assembler::arraycopy_checkcast(Register src, Register src_pos, Register
 
 #ifndef PRODUCT
   if (PrintC1Statistics) {
-    __ add_memory_int32(ExternalAddress((address)&Runtime1::_arraycopy_checkcast_attempt_cnt), 1);
+    __ incrementw(ExternalAddress((address)&Runtime1::_arraycopy_checkcast_attempt_cnt));
   }
 #endif
   assert_different_registers(dst, dst_pos, length, src_pos, src, x10, t0);
@@ -324,7 +324,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
 #ifndef PRODUCT
   if (PrintC1Statistics) {
-    __ add_memory_int32(ExternalAddress(Runtime1::arraycopy_count_address(basic_type)), 1);
+    __ incrementw(ExternalAddress(Runtime1::arraycopy_count_address(basic_type)));
   }
 #endif
   arraycopy_prepare_params(src, src_pos, length, dst, dst_pos, basic_type);

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1065,7 +1065,7 @@ void LIR_Assembler::type_profile_helper(Register mdo, ciMethodData *md, ciProfil
     __ ld(t1, Address(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_offset(i))));
     __ bne(recv, t1, next_test);
     Address data_addr(mdo, md->byte_offset_of_slot(data, ReceiverTypeData::receiver_count_offset(i)));
-    __ add_memory_int64(data_addr, DataLayout::counter_increment);
+    __ increment(data_addr, DataLayout::counter_increment);
     __ j(*update_done);
     __ bind(next_test);
   }
@@ -1563,7 +1563,7 @@ void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
         ciKlass* receiver = vc_data->receiver(i);
         if (known_klass->equals(receiver)) {
           Address data_addr(mdo, md->byte_offset_of_slot(data, VirtualCallData::receiver_count_offset(i)));
-          __ add_memory_int64(data_addr, DataLayout::counter_increment);
+          __ increment(data_addr, DataLayout::counter_increment);
           return;
         }
       }
@@ -1579,7 +1579,7 @@ void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
           __ mov_metadata(t1, known_klass->constant_encoding());
           __ sd(t1, recv_addr);
           Address data_addr(mdo, md->byte_offset_of_slot(data, VirtualCallData::receiver_count_offset(i)));
-          __ add_memory_int64(data_addr, DataLayout::counter_increment);
+          __ increment(data_addr, DataLayout::counter_increment);
           return;
         }
       }
@@ -1589,13 +1589,13 @@ void LIR_Assembler::emit_profile_call(LIR_OpProfileCall* op) {
       type_profile_helper(mdo, md, data, recv, &update_done);
       // Receiver did not match any saved receiver and there is no empty row for it.
       // Increment total counter to indicate polymorphic case.
-      __ add_memory_int64(counter_addr, DataLayout::counter_increment);
+      __ increment(counter_addr, DataLayout::counter_increment);
 
       __ bind(update_done);
     }
   } else {
     // Static call
-    __ add_memory_int64(counter_addr, DataLayout::counter_increment);
+    __ increment(counter_addr, DataLayout::counter_increment);
   }
 }
 

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -105,7 +105,7 @@ int C1_MacroAssembler::lock_object(Register hdr, Register obj, Register disp_hdr
   bind(done);
   if (PrintBiasedLockingStatistics) {
     la(t1, ExternalAddress((address)BiasedLocking::fast_path_entry_count_addr()));
-    add_memory_int32(Address(t1, 0), 1);
+    incrementw(Address(t1, 0));
   }
   return null_check_offset;
 }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3091,19 +3091,47 @@ Address MacroAssembler::add_memory_helper(const Address dst) {
   }
 }
 
-void MacroAssembler::add_memory_int64(const Address dst, int64_t imm) {
+void MacroAssembler::increment(const Address dst, int64_t value) {
+  assert(((dst.getMode() == Address::base_plus_offset &&
+           is_offset_in_range(dst.offset(), 12)) || is_imm_in_range(value, 12, 0)),
+          "invalid value and address mode combination");
   Address adr = add_memory_helper(dst);
-  assert_different_registers(adr.base(), t0);
+  assert(!adr.uses(t0), "invalid dst for address increment");
   ld(t0, adr);
-  addi(t0, t0, imm);
+  add(t0, t0, value, t1);
   sd(t0, adr);
 }
 
-void MacroAssembler::add_memory_int32(const Address dst, int32_t imm) {
+void MacroAssembler::incrementw(const Address dst, int32_t value) {
+  assert(((dst.getMode() == Address::base_plus_offset &&
+           is_offset_in_range(dst.offset(), 12)) || is_imm_in_range(value, 12, 0)),
+          "invalid value and address mode combination");
   Address adr = add_memory_helper(dst);
-  assert_different_registers(adr.base(), t0);
+  assert(!adr.uses(t0), "invalid dst for address increment");
   lwu(t0, adr);
-  addiw(t0, t0, imm);
+  addw(t0, t0, value, t1);
+  sw(t0, adr);
+}
+
+void MacroAssembler::decrement(const Address dst, int64_t value) {
+  assert(((dst.getMode() == Address::base_plus_offset &&
+           is_offset_in_range(dst.offset(), 12)) || is_imm_in_range(value, 12, 0)),
+          "invalid value and address mode combination");
+  Address adr = add_memory_helper(dst);
+  assert(!adr.uses(t0), "invalid dst for address decrement");
+  ld(t0, adr);
+  sub(t0, t0, value, t1);
+  sd(t0, adr);
+}
+
+void MacroAssembler::decrementw(const Address dst, int32_t value) {
+  assert(((dst.getMode() == Address::base_plus_offset &&
+           is_offset_in_range(dst.offset(), 12)) || is_imm_in_range(value, 12, 0)),
+          "invalid value and address mode combination");
+  Address adr = add_memory_helper(dst);
+  assert(!adr.uses(t0), "invalid dst for address decrement");
+  lwu(t0, adr);
+  subw(t0, t0, value, t1);
   sw(t0, adr);
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -654,8 +654,19 @@ class MacroAssembler: public Assembler {
   address trampoline_call(Address entry, CodeBuffer* cbuf = NULL);
   address ic_call(address entry, jint method_index = 0);
 
-  void add_memory_int64(const Address dst, int64_t imm);
-  void add_memory_int32(const Address dst, int32_t imm);
+  // Support for memory inc/dec
+  // n.b. increment/decrement calls with an Address destination will
+  // need to use a scratch register to load the value to be
+  // incremented. increment/decrement calls which add or subtract a
+  // constant value other than sign-extended 12-bit immediate will need
+  // to use a 2nd scratch register to hold the constant. so, an address
+  // increment/decrement may trash both t0 and t1.
+
+  void increment(const Address dst, int64_t value = 1);
+  void incrementw(const Address dst, int32_t value = 1);
+
+  void decrement(const Address dst, int64_t value = 1);
+  void decrementw(const Address dst, int32_t value = 1);
 
   void cmpptr(Register src1, Address src2, Label& equal);
 

--- a/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
@@ -72,7 +72,7 @@ VtableStub* VtableStubs::create_vtable_stub(int vtable_index) {
 #if (!defined(PRODUCT) && defined(COMPILER2))
   if (CountCompiledCalls) {
     __ la(t2, ExternalAddress((address) SharedRuntime::nof_megamorphic_calls_addr()));
-    __ add_memory_int64(Address(t2), 1);
+    __ increment(Address(t2));
   }
 #endif
 
@@ -163,7 +163,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
 #if (!defined(PRODUCT) && defined(COMPILER2))
   if (CountCompiledCalls) {
     __ la(x18, ExternalAddress((address) SharedRuntime::nof_megamorphic_calls_addr()));
-    __ add_memory_int64(Address(x18), 1);
+    __ increment(Address(x18));
   }
 #endif
 


### PR DESCRIPTION
Please review this backport to riscv-port-jdk11u.
Backport of [JDK-8290137](https://bugs.openjdk.org/browse/JDK-8290137). Applies not cleanly because [JDK-8339248](https://bugs.openjdk.org/browse/JDK-8339248) remove li64 macro assembler routine and related code. 

So I removed the changes of the li64 macro assembler routine. In addition to this there was an extra modification to `add_memory_int32` in `c1_MacroAssembler_riscv.cpp`.

Testing:
- Tier1 passed without new failure on lp4a (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290137](https://bugs.openjdk.org/browse/JDK-8290137): riscv: small refactoring for add_memory_int32/64 (**Enhancement** - P4)


### Reviewers
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/30.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/30.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/30#issuecomment-2342576784)