### PR TITLE
8293474: RISC-V: Unify the way of moving function pointer

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -388,7 +388,7 @@ void MacroAssembler::verify_oop(Register reg, const char* s) {
   // The length of the instruction sequence emitted should be independent
   // of the values of the local char buffer address so that the size of mach
   // nodes for scratch emit and normal emit matches.
-  mv(t0, (address)b);
+  movptr(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;
@@ -427,7 +427,7 @@ void MacroAssembler::verify_oop_addr(Address addr, const char* s) {
   // The length of the instruction sequence emitted should be independent
   // of the values of the local char buffer address so that the size of mach
   // nodes for scratch emit and normal emit matches.
-  mv(t0, (address)b);
+  movptr(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;
@@ -1291,12 +1291,6 @@ void MacroAssembler::mv(Register Rd, Address dest) {
   assert(dest.getMode() == Address::literal, "Address mode should be Address::literal");
   code_section()->relocate(pc(), dest.rspec());
   movptr(Rd, dest.target());
-}
-
-void MacroAssembler::mv(Register Rd, address addr) {
-  // Here in case of use with relocation, use fix length instruction
-  // movptr instead of li
-  movptr(Rd, addr);
 }
 
 void MacroAssembler::mv(Register Rd, RegisterOrConstant src) {
@@ -2615,11 +2609,10 @@ void MacroAssembler::get_thread(Register thread) {
                       RegSet::range(x28, x31) + ra - thread;
   push_reg(saved_regs, sp);
 
-  int32_t offset = 0;
-  movptr_with_offset(ra, CAST_FROM_FN_PTR(address, Thread::current), offset);
-  jalr(ra, ra, offset);
-  if (thread != x10) {
-    mv(thread, x10);
+  mv(ra, CAST_FROM_FN_PTR(address, Thread::current));
+  jalr(ra);
+  if (thread != c_rarg0) {
+    mv(thread, c_rarg0);
   }
 
   // restore pushed registers

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -530,6 +530,8 @@ class MacroAssembler: public Assembler {
   }
 
   // mv
+  void mv(Register Rd, address addr)          { li(Rd, (int64_t)addr); }
+
   inline void mv(Register Rd, int imm64)                { li(Rd, (int64_t)imm64); }
   inline void mv(Register Rd, long imm64)               { li(Rd, (int64_t)imm64); }
   inline void mv(Register Rd, long long imm64)          { li(Rd, (int64_t)imm64); }
@@ -540,7 +542,6 @@ class MacroAssembler: public Assembler {
   inline void mvw(Register Rd, int32_t imm32) { mv(Rd, imm32); }
 
   void mv(Register Rd, Address dest);
-  void mv(Register Rd, address dest);
   void mv(Register Rd, RegisterOrConstant src);
 
   // logic


### PR DESCRIPTION
Please review this backport to riscv-port-jdk11u.
Backport of [JDK-8293474](https://bugs.openjdk.org/browse/JDK-8293474).
Applies not cleanly due to context difference, and changes in `shenandoahBarrierSetAssembler_riscv.cpp` have been modified previously.

Testing:
- Tier1 passed without new failure on lp4a (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293474](https://bugs.openjdk.org/browse/JDK-8293474): RISC-V: Unify the way of moving function pointer (**Enhancement** - P4)


### Reviewers
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/33.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/33.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/33#issuecomment-2378310780)