### PR TITLE
8339741: RISC-V: C ABI breakage for integer on stack

### DIFF
--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -704,15 +704,21 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
   return stk_args;
 }
 
-// On 64 bit we will store integer like items to the stack as
-// 64 bits items (riscv64 abi) even though java would only store
-// 32bits for a parameter. On 32bit it will simply be 32 bits
-// So this routine will do 32->32 on 32bit and 32->64 on 64bit
+// The C ABI specifies:
+// "integer scalars narrower than XLEN bits are widened according to the sign
+// of their type up to 32 bits, then sign-extended to XLEN bits."
+// Applies for both passed in register and stack.
+//
+// Java uses 32-bit stack slots; jint, jshort, jchar, jbyte uses one slot.
+// Native uses 64-bit stack slots for all integer scalar types.
+//
+// lw loads the Java stack slot, sign-extends and
+// sd store this widened integer into a 64 bit native stack slot.
 static void move32_64(MacroAssembler* masm, VMRegPair src, VMRegPair dst) {
   if (src.first()->is_stack()) {
     if (dst.first()->is_stack()) {
       // stack to stack
-      __ ld(t0, Address(fp, reg2offset_in(src.first())));
+      __ lw(t0, Address(fp, reg2offset_in(src.first())));
       __ sd(t0, Address(sp, reg2offset_out(dst.first())));
     } else {
       // stack to reg

--- a/test/hotspot/jtreg/compiler/calls/TestManyArgs.java
+++ b/test/hotspot/jtreg/compiler/calls/TestManyArgs.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Rivos Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @summary Pass values on stack.
+ * @requires os.arch == "riscv64"
+ * @run main/native compiler.calls.TestManyArgs
+ */
+
+package compiler.calls;
+
+public class TestManyArgs {
+    static {
+        System.loadLibrary("TestManyArgs");
+    }
+
+    native static void scramblestack();
+
+    native static int checkargs(int arg0, short arg1, byte arg2,
+                                int arg3, short arg4, byte arg5,
+                                int arg6, short arg7, byte arg8,
+                                int arg9, short arg10, byte arg11);
+
+    static int compiledbridge(int arg0, short arg1, byte arg2,
+                              int arg3, short arg4, byte arg5,
+                              int arg6, short arg7, byte arg8,
+                              int arg9, short arg10, byte arg11) {
+        return checkargs(arg0, arg1, arg2, arg3, arg4, arg5,
+                         arg6, arg7, arg8, arg9, arg10, arg11);
+    }
+
+    static public void main(String[] args) {
+        scramblestack();
+        for (int i = 0; i < 20000; i++) {
+            int res = compiledbridge((int)0xf, (short)0xf, (byte)0xf,
+                                     (int)0xf, (short)0xf, (byte)0xf,
+                                     (int)0xf, (short)0xf, (byte)0xf,
+                                     (int)0xf, (short)0xf, (byte)0xf);
+            if (res != 0) {
+                throw new RuntimeException("Test failed");
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/calls/libTestManyArgs.c
+++ b/test/hotspot/jtreg/compiler/calls/libTestManyArgs.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Rivos Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+
+#ifdef riscv64
+/* RV64 ABI pass all integers as 64-bit, in registers or on stack
+ * As compiler may choose to load smaller width than 64-bit if passed on stack,
+ * this test may not find any bugs.
+ * Therefore we trick the compiler todo 64-bit loads,
+ * by saying these args are jlongs.
+ */
+JNIEXPORT jint JNICALL Java_compiler_calls_TestManyArgs_checkargs(JNIEnv* env, jclass jclazz,
+                                                                  jlong arg0, jlong arg1, jlong arg2,
+                                                                  jlong arg3, jlong arg4, jlong arg5,
+                                                                  jlong arg6, jlong arg7, jlong arg8,
+                                                                  jlong arg9, jlong arg10, jlong arg11)
+#else
+JNIEXPORT jint JNICALL Java_compiler_calls_TestManyArgs_checkargs(JNIEnv* env, jclass jclazz,
+                                                                  jint arg0, jshort arg1, jbyte arg2,
+                                                                  jint arg3, jshort arg4, jbyte arg5,
+                                                                  jint arg6, jshort arg7, jbyte arg8,
+                                                                  jint arg9, jshort arg10, jbyte arg11)
+#endif
+{
+    if (arg0 != 0xf) return 1;
+    if (arg1 != 0xf) return 1;
+    if (arg2 != 0xf) return 1;
+    if (arg3 != 0xf) return 1;
+    if (arg4 != 0xf) return 1;
+    if (arg5 != 0xf) return 1;
+    if (arg6 != 0xf) return 1;
+    if (arg7 != 0xf) return 1;
+    if (arg8 != 0xf) return 1;
+    if (arg9 != 0xf) return 1;
+    if (arg10 != 0xf) return 1;
+    if (arg11 != 0xf) return 1;
+    return 0;
+}
+
+JNIEXPORT
+void JNICALL Java_compiler_calls_TestManyArgs_scramblestack(JNIEnv* env, jclass jclazz)
+{
+    volatile char stack[12*8];
+    for (unsigned int i = 0; i < sizeof(stack); i++) {
+        stack[i] = (char)0xff;
+    }
+}


### PR DESCRIPTION
Hi all, 

Please review this backport to riscv-port-jdk11u.

Backport of [JDK-8339741](https://bugs.openjdk.org/browse/JDK-8339741).

The original patch cannot be directly applied because jdk11u has no [JDK-8294100](https://bugs.openjdk.org/browse/JDK-8294100).

Testing:
- Tier1 passed without new failure on lp4a (release).
- New jtreg test: test/hotspot/jtreg/compiler/calls/TestManyArgs.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339741](https://bugs.openjdk.org/browse/JDK-8339741): RISC-V: C ABI breakage for integer on stack (**Bug** - P3)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/35.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/35.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/35#issuecomment-2381061027)