### PR TITLE
8294012: RISC-V: get/put_native_u8 missing the case when address&7 is 6

### DIFF
--- a/src/hotspot/cpu/riscv/bytes_riscv.hpp
+++ b/src/hotspot/cpu/riscv/bytes_riscv.hpp
@@ -73,6 +73,7 @@ class Bytes: AllStatic {
                ((u8)(((u4*)p)[0]));
 
       case 2:
+      case 6:
         return ((u8)(((u2*)p)[3]) << 48) |
                ((u8)(((u2*)p)[2]) << 32) |
                ((u8)(((u2*)p)[1]) << 16) |
@@ -131,6 +132,7 @@ class Bytes: AllStatic {
         break;
 
       case 2:
+      case 6:
         ((u2*)p)[3] = x >> 48;
         ((u2*)p)[2] = x >> 32;
         ((u2*)p)[1] = x >> 16;


### PR DESCRIPTION
Hi all, 

Please review this backport to riscv-port-jdk11u.

Backport of [JDK-8294012](https://bugs.openjdk.org/browse/JDK-8294012). Applies cleanly.

Testing:
- Tier1 passed without new failure on lp4a (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294012](https://bugs.openjdk.org/browse/JDK-8294012): RISC-V: get/put_native_u8 missing the case when address&amp;7 is 6 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Gui Cao](https://openjdk.org/census#gcao) (@zifeihan - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/37.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/37.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/37#issuecomment-2406490063)