### PR TITLE
Revert "8293474: RISC-V: Unify the way of moving function pointer"

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -387,7 +387,7 @@ void MacroAssembler::verify_oop(Register reg, const char* s) {
   // The length of the instruction sequence emitted should be independent
   // of the values of the local char buffer address so that the size of mach
   // nodes for scratch emit and normal emit matches.
-  movptr(t0, (address)b);
+  mv(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;
@@ -426,7 +426,7 @@ void MacroAssembler::verify_oop_addr(Address addr, const char* s) {
   // The length of the instruction sequence emitted should be independent
   // of the values of the local char buffer address so that the size of mach
   // nodes for scratch emit and normal emit matches.
-  movptr(t0, (address)b);
+  mv(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;
@@ -1291,6 +1291,12 @@ void MacroAssembler::mv(Register Rd, Address dest) {
   assert(dest.getMode() == Address::literal, "Address mode should be Address::literal");
   code_section()->relocate(pc(), dest.rspec());
   movptr(Rd, dest.target());
+}
+
+void MacroAssembler::mv(Register Rd, address addr) {
+  // Here in case of use with relocation, use fix length instruction
+  // movptr instead of li
+  movptr(Rd, addr);
 }
 
 void MacroAssembler::mv(Register Rd, RegisterOrConstant src) {
@@ -2609,10 +2615,11 @@ void MacroAssembler::get_thread(Register thread) {
                       RegSet::range(x28, x31) + ra - thread;
   push_reg(saved_regs, sp);
 
-  mv(ra, CAST_FROM_FN_PTR(address, Thread::current));
-  jalr(ra);
-  if (thread != c_rarg0) {
-    mv(thread, c_rarg0);
+  int32_t offset = 0;
+  movptr_with_offset(ra, CAST_FROM_FN_PTR(address, Thread::current), offset);
+  jalr(ra, ra, offset);
+  if (thread != x10) {
+    mv(thread, x10);
   }
 
   // restore pushed registers

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -535,8 +535,6 @@ public:
   }
 
   // mv
-  void mv(Register Rd, address addr)          { li(Rd, (int64_t)addr); }
-
   inline void mv(Register Rd, int imm64)                { li(Rd, (int64_t)imm64); }
   inline void mv(Register Rd, long imm64)               { li(Rd, (int64_t)imm64); }
   inline void mv(Register Rd, long long imm64)          { li(Rd, (int64_t)imm64); }
@@ -547,6 +545,7 @@ public:
   inline void mvw(Register Rd, int32_t imm32) { mv(Rd, imm32); }
 
   void mv(Register Rd, Address dest);
+  void mv(Register Rd, address dest);
   void mv(Register Rd, RegisterOrConstant src);
 
   // logic


### PR DESCRIPTION
This reverts commit d46c73c4d90670a06f8351bde444a3f4e5c0fc41.

It breaks the bootstrap build.

```
 1538	Epilog	===  [[]]   [-2145780538]
# pop frame 80
	add  sp, sp, #80
	ld  ra, [sp,#-16]
	ld  fp, [sp,#-8]
	 n_size (264), current_offset (3340), instr_offset (3068)
Could not load hsdis-riscv64.so; library not loadable; PrintAssembly is disabled
 ------------------- 
# To suppress the following error report, specify this argument
# after -XX: or in .hotspotrc:  SuppressErrorAt=/output.cpp:1416
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/abuild/rpmbuild/BUILD/jdk11u-jdk-11.0.24-8/src/hotspot/share/opto/output.cpp:1416), pid=243370, tid=246224
#  assert(false) failed: wrong size of mach node
#
# JRE version: OpenJDK Runtime Environment (11.0.25+8) (slowdebug build 11.0.25+8-suse-378.1-riscv64)
# Java VM: OpenJDK 64-Bit Server VM (slowdebug 11.0.25+8-suse-378.1-riscv64, mixed mode, tiered, compressed oops, g1 gc, linux-riscv64)
# Core dump will be written. Default location: /.build/cores/243370
#
# An error report file with more information is saved as:
# /home/abuild/rpmbuild/BUILD/jdk11u-jdk-11.0.24-8/make/hs_err_pid243370.log
gmake[3]: *** [Docs.gmk:432: /home/abuild/rpmbuild/BUILD/jdk11u-jdk-11.0.24-8/build/images/docs/api/index.html] Error 134
gmake[3]: Leaving directory '/home/abuild/rpmbuild/BUILD/jdk11u-jdk-11.0.24-8/make'
gmake[2]: *** [make/Main.gmk:427: docs-jdk-api-javadoc] Error 2
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/41.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/41.diff</a>

</details>
