### PR TITLE
8295110: RISC-V: Mark out relocations as incompressible

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -188,6 +188,7 @@ void Assembler::ret() {
     switch (adr.getMode()) {                                   \
       case Address::literal: {                                 \
         relocate(adr.rspec());                                 \
+        IncompressibleRegion ir(this);                         \
         NAME(adr.target(), temp);                              \
         break;                                                 \
       }                                                        \

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2058,13 +2058,13 @@ enum Nf {
 //     versions. An example:
 //
 //      CompressibleRegion cr(_masm);
-//      __ add(...);       // this instruction will be compressed into 'c.and' when possible
+//      __ add(...);       // this instruction will be compressed into 'c.add' when possible
 //      {
 //         IncompressibleRegion ir(_masm);
 //         __ add(...);    // this instruction will not be compressed
 //         {
 //            CompressibleRegion cr(_masm);
-//            __ add(...); // this instruction will be compressed into 'c.and' when possible
+//            __ add(...); // this instruction will be compressed into 'c.add' when possible
 //         }
 //      }
 //

--- a/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
@@ -87,9 +87,14 @@ void RangeCheckStub::emit_code(LIR_Assembler* ce) {
     __ mv(t1, _array->as_pointer_register());
     stub_id = Runtime1::throw_range_check_failed_id;
   }
-  int32_t off = 0;
-  __ la_patchable(ra, RuntimeAddress(Runtime1::entry_for(stub_id)), off);
-  __ jalr(ra, ra, off);
+  RuntimeAddress target(Runtime1::entry_for(stub_id));
+  {
+    __ relocate(target.rspec());
+    Assembler::IncompressibleRegion ir(ce->masm());
+    int32_t offset;
+    __ la_patchable(ra, target, offset);
+    __ jalr(ra, ra, offset);
+  }
   ce->add_call_info_here(_info);
   ce->verify_oop_map(_info);
   debug_only(__ should_not_reach_here());

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1422,9 +1422,13 @@ void LIR_Assembler::throw_op(LIR_Opr exceptionPC, LIR_Opr exceptionOop, CodeEmit
   }
   int pc_for_athrow_offset = __ offset();
   InternalAddress pc_for_athrow(__ pc());
-  int32_t off = 0;
-  __ la_patchable(exceptionPC->as_register(), pc_for_athrow, off);
-  __ addi(exceptionPC->as_register(), exceptionPC->as_register(), off);
+  {
+    __ relocate(pc_for_athrow.rspec());
+    Assembler::IncompressibleRegion ir(_masm);
+    int32_t offset;
+    __ la_patchable(exceptionPC->as_register(), pc_for_athrow, offset);
+    __ addi(exceptionPC->as_register(), exceptionPC->as_register(), offset);
+  }
   add_call_info(pc_for_athrow_offset, info); // for exception handler
 
   __ verify_not_null_oop(x10);
@@ -1838,9 +1842,14 @@ void LIR_Assembler::rt_call(LIR_Opr result, address dest, const LIR_OprList* arg
   if (cb != NULL) {
     __ far_call(RuntimeAddress(dest));
   } else {
-    int32_t offset = 0;
-    __ la_patchable(t0, RuntimeAddress(dest), offset);
-    __ jalr(x1, t0, offset);
+    RuntimeAddress target(dest);
+    {
+      __ relocate(target.rspec());
+      Assembler::IncompressibleRegion ir(_masm);
+      int32_t offset;
+      __ la_patchable(t0, target, offset);
+      __ jalr(x1, t0, offset);
+    }
   }
 
   if (info != NULL) {

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -66,9 +66,14 @@ int StubAssembler::call_RT(Register oop_result, Register metadata_result, addres
   set_last_Java_frame(sp, fp, retaddr, t0);
 
   // do the call
-  int32_t off = 0;
-  la_patchable(t0, RuntimeAddress(entry), off);
-  jalr(x1, t0, off);
+  RuntimeAddress target(entry);
+  {
+    relocate(target.rspec());
+    IncompressibleRegion ir(this);
+    int32_t offset;
+    la_patchable(t0, target, offset);
+    jalr(x1, t0, offset);
+  }
   bind(retaddr);
   int call_offset = offset();
   // verify callee-saved register
@@ -562,9 +567,14 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
   Label retaddr;
   __ set_last_Java_frame(sp, fp, retaddr, t0);
   // do the call
-  int32_t off = 0;
-  __ la_patchable(t0, RuntimeAddress(target), off);
-  __ jalr(x1, t0, off);
+  RuntimeAddress addr(target);
+  {
+    __ relocate(addr.rspec());
+    Assembler::IncompressibleRegion ir(sasm);
+    int32_t offset;
+    __ la_patchable(t0, addr, offset);
+    __ jalr(x1, t0, offset);
+  }
   __ bind(retaddr);
   OopMapSet* oop_maps = new OopMapSet();
   assert_cond(oop_maps != NULL);

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -175,6 +175,8 @@ void BarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register obj,
     // Get the current end of the heap
     ExternalAddress address_end((address) Universe::heap()->end_addr());
     {
+      __ relocate(address_end.rspec());
+      Assembler::IncompressibleRegion ir(masm);
       int32_t offset;
       __ la_patchable(t1, address_end, offset);
       __ ld(t1, Address(t1, offset));
@@ -183,9 +185,13 @@ void BarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register obj,
     // Get the current top of the heap
     ExternalAddress address_top((address) Universe::heap()->top_addr());
     {
-      int32_t offset;
-      __ la_patchable(t0, address_top, offset);
-      __ addi(t0, t0, offset);
+      {
+        __ relocate(address_top.rspec());
+        Assembler::IncompressibleRegion ir(masm);
+        int32_t offset;
+        __ la_patchable(t0, address_top, offset);
+        __ addi(t0, t0, offset);
+      }
       __ lr_d(obj, t0, Assembler::aqrl);
     }
 

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -102,10 +102,10 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Extend i for r and o for w in the pred/succ flags of fence")          \
   product(bool, AvoidUnalignedAccesses, true,                                    \
           "Avoid generating unaligned memory accesses")                          \
+  product(bool, UseRVC, true,  "Use RVC instructions")                           \
   experimental(bool, UseRVV, false, "Use RVV instructions")                      \
   experimental(bool, UseZba, false, "Use Zba instructions")                      \
   experimental(bool, UseZbb, false, "Use Zbb instructions")                      \
-  experimental(bool, UseZbs, false, "Use Zbs instructions")                      \
-  experimental(bool, UseRVC, false, "Use RVC instructions")
+  experimental(bool, UseZbs, false, "Use Zbs instructions")
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -181,9 +181,14 @@ void InterpreterMacroAssembler::get_unsigned_2_byte_index_at_bcp(Register reg, i
 }
 
 void InterpreterMacroAssembler::get_dispatch() {
-  int32_t offset = 0;
-  la_patchable(xdispatch, ExternalAddress((address)Interpreter::dispatch_table()), offset);
-  addi(xdispatch, xdispatch, offset);
+  ExternalAddress target((address)Interpreter::dispatch_table());
+  {
+    relocate(target.rspec());
+    IncompressibleRegion ir(this);
+    int32_t offset;
+    la_patchable(xdispatch, target, offset);
+    addi(xdispatch, xdispatch, offset);
+  }
 }
 
 void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -346,9 +346,14 @@ void MacroAssembler::call_VM_base(Register oop_result,
     ld(t0, Address(java_thread, in_bytes(Thread::pending_exception_offset())));
     Label ok;
     beqz(t0, ok);
-    int32_t offset = 0;
-    la_patchable(t0, RuntimeAddress(StubRoutines::forward_exception_entry()), offset);
-    jalr(x0, t0, offset);
+    RuntimeAddress target(StubRoutines::forward_exception_entry());
+    {
+      relocate(target.rspec());
+      IncompressibleRegion ir(this);
+      int32_t offset;
+      la_patchable(t0, target, offset);
+      jalr(x0, t0, offset);
+    }
     bind(ok);
   }
 
@@ -394,9 +399,14 @@ void MacroAssembler::verify_oop(Register reg, const char* s) {
   }
 
   // call indirectly to solve generation ordering problem
-  int32_t offset = 0;
-  la_patchable(t1, ExternalAddress(StubRoutines::verify_oop_subroutine_entry_address()), offset);
-  ld(t1, Address(t1, offset));
+  ExternalAddress target(StubRoutines::verify_oop_subroutine_entry_address());
+  {
+    relocate(target.rspec());
+    IncompressibleRegion ir(this);
+    int32_t offset;
+    la_patchable(t1, target, offset);
+    ld(t1, Address(t1, offset));
+  }
   jalr(t1);
 
   pop_reg(RegSet::of(ra, t0, t1, c_rarg0), sp);
@@ -436,9 +446,14 @@ void MacroAssembler::verify_oop_addr(Address addr, const char* s) {
   }
 
   // call indirectly to solve generation ordering problem
-  int32_t offset = 0;
-  la_patchable(t1, ExternalAddress(StubRoutines::verify_oop_subroutine_entry_address()), offset);
-  ld(t1, Address(t1, offset));
+  ExternalAddress target(StubRoutines::verify_oop_subroutine_entry_address());
+  {
+    relocate(target.rspec());
+    IncompressibleRegion ir(this);
+    int32_t offset;
+    la_patchable(t1, target, offset);
+    ld(t1, Address(t1, offset));
+  }
   jalr(t1);
 
   pop_reg(RegSet::of(ra, t0, t1, c_rarg0), sp);
@@ -762,6 +777,7 @@ void MacroAssembler::la(Register Rd, const Address &adr) {
         mv(Rd, (intptr_t)(adr.target()));
       } else {
         relocate(adr.rspec());
+        IncompressibleRegion ir(this);
         movptr(Rd, adr.target());
       }
       break;
@@ -1288,17 +1304,25 @@ void MacroAssembler::reinit_heapbase() {
     if (Universe::is_fully_initialized()) {
       mv(xheapbase, Universe::narrow_ptrs_base());
     } else {
-      int32_t offset = 0;
-      la_patchable(xheapbase, ExternalAddress((address)Universe::narrow_ptrs_base_addr()), offset);
-      ld(xheapbase, Address(xheapbase, offset));
+      ExternalAddress target((address)Universe::narrow_ptrs_base_addr());
+      {
+        relocate(target.rspec());
+        IncompressibleRegion ir(this);
+        int32_t offset;
+        la_patchable(xheapbase, target, offset);
+        ld(xheapbase, Address(xheapbase, offset));
+      }
     }
   }
 }
 
 void MacroAssembler::mv(Register Rd, Address dest) {
   assert(dest.getMode() == Address::literal, "Address mode should be Address::literal");
-  relocate(dest.rspec());
-  movptr(Rd, dest.target());
+  {
+    relocate(dest.rspec());
+    IncompressibleRegion ir(this);
+    movptr(Rd, dest.target());
+  }
 }
 
 void MacroAssembler::mv(Register Rd, RegisterOrConstant src) {
@@ -1645,8 +1669,14 @@ void MacroAssembler::bang_stack_size(Register size, Register tmp) {
 SkipIfEqual::SkipIfEqual(MacroAssembler* masm, const bool* flag_addr, bool value) {
   int32_t offset = 0;
   _masm = masm;
-  _masm->la_patchable(t0, ExternalAddress((address)flag_addr), offset);
-  _masm->lbu(t0, Address(t0, offset));
+  ExternalAddress target((address)flag_addr);
+  {
+    _masm->relocate(target.rspec());
+    Assembler::IncompressibleRegion ir(_masm);
+    int32_t offset;
+    _masm->la_patchable(t0, target, offset);
+    _masm->lbu(t0, Address(t0, offset));
+  }
   _masm->beqz(t0, _label);
 }
 
@@ -2078,8 +2108,13 @@ void MacroAssembler::safepoint_poll(Label& slow_path) {
     bnez(t0, slow_path);
   } else {
     int32_t offset = 0;
-    la_patchable(t0, ExternalAddress(SafepointSynchronize::address_of_state()), offset);
-    lwu(t0, Address(t0, offset));
+    ExternalAddress target(SafepointSynchronize::address_of_state());
+    {
+      relocate(target.rspec());
+      IncompressibleRegion ir(this);
+      la_patchable(t0, target, offset);
+      lwu(t0, Address(t0, offset));
+    }
     assert(SafepointSynchronize::_not_synchronized == 0, "rewrite this code");
     bnez(t0, slow_path);
   }
@@ -2372,13 +2407,17 @@ void MacroAssembler::far_jump(Address entry, CodeBuffer *cbuf, Register tmp) {
   assert(CodeCache::find_blob(entry.target()) != NULL,
          "destination of far call not found in code cache");
   IncompressibleRegion ir(this);  // Fixed length: see MacroAssembler::far_branch_size()
-  int32_t offset = 0;
   if (far_branches()) {
     // We can use auipc + jalr here because we know that the total size of
     // the code cache cannot exceed 2Gb.
-    la_patchable(tmp, entry, offset);
-    if (cbuf != NULL) { cbuf->set_insts_mark(); }
-    jalr(x0, tmp, offset);
+    {
+      relocate(entry.rspec());
+      IncompressibleRegion ir(this);
+      int32_t offset;
+      la_patchable(tmp, entry, offset);
+      if (cbuf != NULL) { cbuf->set_insts_mark(); }
+      jalr(x0, tmp, offset);
+    }
   } else {
     if (cbuf != NULL) { cbuf->set_insts_mark(); }
     j(entry);
@@ -2390,13 +2429,17 @@ void MacroAssembler::far_call(Address entry, CodeBuffer *cbuf, Register tmp) {
   assert(CodeCache::find_blob(entry.target()) != NULL,
          "destination of far call not found in code cache");
   IncompressibleRegion ir(this);  // Fixed length: see MacroAssembler::far_branch_size()
-  int32_t offset = 0;
   if (far_branches()) {
     // We can use auipc + jalr here because we know that the total size of
     // the code cache cannot exceed 2Gb.
-    la_patchable(tmp, entry, offset);
-    if (cbuf != NULL) { cbuf->set_insts_mark(); }
-    jalr(x1, tmp, offset); // link
+    {
+      relocate(entry.rspec());
+      IncompressibleRegion ir(this);
+      int32_t offset;
+      la_patchable(tmp, entry, offset);
+      if (cbuf != NULL) { cbuf->set_insts_mark(); }
+      jalr(x1, tmp, offset); // link
+    }
   } else {
     if (cbuf != NULL) { cbuf->set_insts_mark(); }
     jal(entry); // link
@@ -2646,7 +2689,6 @@ void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &o
   assert(is_valid_riscv64_address(dest.target()), "bad address");
   assert(dest.getMode() == Address::literal, "la_patchable must be applied to a literal address");
 
-  relocate(dest.rspec());
   // RISC-V doesn't compute a page-aligned address, in order to partially
   // compensate for the use of *signed* offsets in its base+disp12
   // addressing mode (RISC-V's PC-relative reach remains asymmetric
@@ -2686,17 +2728,27 @@ void MacroAssembler::reserved_stack_check() {
 
     enter();   // RA and FP are live.
     mv(c_rarg0, xthread);
-    int32_t offset = 0;
-    la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone)), offset);
-    jalr(x1, t0, offset);
+    RuntimeAddress target(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone));
+    {
+      relocate(target.rspec());
+      IncompressibleRegion ir(this);
+      int32_t offset;
+      la_patchable(t0, target, offset);
+      jalr(x1, t0, offset);
+    }
     leave();
 
     // We have already removed our own frame.
     // throw_delayed_StackOverflowError will think that it's been
     // called by our caller.
-    offset = 0;
-    la_patchable(t0, RuntimeAddress(StubRoutines::throw_delayed_StackOverflowError_entry()), offset);
-    jalr(x0, t0, offset);
+    target = RuntimeAddress(StubRoutines::throw_delayed_StackOverflowError_entry());
+    {
+      relocate(target.rspec());
+      IncompressibleRegion ir(this);
+      int32_t offset;
+      la_patchable(t0, target, offset);
+      jalr(x0, t0, offset);
+    }
     should_not_reach_here();
 
     bind(no_reserved_zone_enabling);
@@ -2925,12 +2977,17 @@ void MacroAssembler::get_polling_page(Register dest, address page, int32_t &offs
   } else {
     uint64_t align = (uint64_t)page & 0xfff;
     assert(align == 0, "polling page must be page aligned");
-    la_patchable(dest, Address(page, rtype), offset);
+    Address target(page, rtype);
+    {
+      relocate(target.rspec());
+      IncompressibleRegion ir(this);
+      la_patchable(dest, target, offset);
+    }
   }
 }
 
 // Read the polling page.  The address of the polling page must
-// already be in r.
+// already be in dest.
 void MacroAssembler::read_polling_page(Register dest, address page, relocInfo::relocType rtype) {
   int32_t offset = 0;
   get_polling_page(dest, page, offset, rtype);
@@ -2938,9 +2995,10 @@ void MacroAssembler::read_polling_page(Register dest, address page, relocInfo::r
 }
 
 // Read the polling page.  The address of the polling page must
-// already be in r.
+// already be in dest.
 void MacroAssembler::read_polling_page(Register dest, int32_t offset, relocInfo::relocType rtype) {
   relocate(rtype);
+  IncompressibleRegion ir(this);
   lwu(zr, Address(dest, offset));
 }
 
@@ -2955,8 +3013,11 @@ void  MacroAssembler::set_narrow_oop(Register dst, jobject obj) {
   }
 #endif
   int oop_index = oop_recorder()->find_index(obj);
-  relocate(oop_Relocation::spec(oop_index));
-  li32(dst, 0xDEADBEEF);
+  {
+    relocate(oop_Relocation::spec(oop_index));
+    IncompressibleRegion ir(this);
+    li32(dst, 0xDEADBEEF);
+  }
   zero_extend(dst, dst, 32);
 }
 
@@ -2967,8 +3028,11 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
   assert(!Universe::heap()->is_in_reserved(k), "should not be an oop");
 
   narrowKlass nk = Klass::encode_klass(k);
-  relocate(metadata_Relocation::spec(index));
-  li32(dst, nk);
+  {
+    relocate(metadata_Relocation::spec(index));
+    IncompressibleRegion ir(this);
+    li32(dst, nk);
+  }
   zero_extend(dst, dst, 32);
 }
 
@@ -3007,11 +3071,14 @@ address MacroAssembler::trampoline_call(Address entry, CodeBuffer* cbuf) {
     assert_alignment(pc());
   }
 #endif
-  relocate(entry.rspec());
-  if (!far_branches()) {
-    jal(entry.target());
-  } else {
-    jal(pc());
+  {
+    relocate(entry.rspec());
+    IncompressibleRegion ir(this);
+    if (!far_branches()) {
+      jal(entry.target());
+    } else {
+      jal(pc());
+    }
   }
   // just need to return a non-null address
   postcond(pc() != badAddress);
@@ -3020,6 +3087,7 @@ address MacroAssembler::trampoline_call(Address entry, CodeBuffer* cbuf) {
 
 address MacroAssembler::ic_call(address entry, jint method_index) {
   RelocationHolder rh = virtual_call_Relocation::spec(pc(), method_index);
+  IncompressibleRegion ir(this);  // relocations
   movptr(t1, (address)Universe::non_oop_word());
   assert_cond(entry != NULL);
   return trampoline_call(Address(entry, rh));
@@ -3053,21 +3121,24 @@ address MacroAssembler::emit_trampoline_stub(int insts_call_instruction_offset,
   // when we reach here we may get a 2-byte alignment so need to align it
   align(wordSize, NativeCallTrampolineStub::data_offset);
 
-  relocate(trampoline_stub_Relocation::spec(code()->insts()->start() +
-                                            insts_call_instruction_offset));
+  RelocationHolder rh = trampoline_stub_Relocation::spec(code()->insts()->start() +
+                                                         insts_call_instruction_offset);
   const int stub_start_offset = offset();
-
-  // Now, create the trampoline stub's code:
-  // - load the call
-  // - call
-  Label target;
-  ld(t0, target);  // auipc + ld
-  jr(t0);          // jalr
-  bind(target);
-  assert(offset() - stub_start_offset == NativeCallTrampolineStub::data_offset,
-         "should be");
-  assert(offset() % wordSize == 0, "bad alignment");
-  emit_int64((intptr_t)dest);
+  {
+    relocate(rh);
+    IncompressibleRegion ir(this);
+    // Now, create the trampoline stub's code:
+    // - load the call
+    // - call
+    Label target;
+    ld(t0, target);  // auipc + ld
+    jr(t0);          // jalr
+    bind(target);
+    assert(offset() - stub_start_offset == NativeCallTrampolineStub::data_offset,
+           "should be");
+    assert(offset() % wordSize == 0, "bad alignment");
+    emit_int64((int64_t)dest);
+  }
 
   const address stub_start_addr = addr_at(stub_start_offset);
 
@@ -3135,9 +3206,13 @@ void MacroAssembler::decrementw(const Address dst, int32_t value) {
 
 void MacroAssembler::cmpptr(Register src1, Address src2, Label& equal) {
   assert_different_registers(src1, t0);
-  int32_t offset;
-  la_patchable(t0, src2, offset);
-  ld(t0, Address(t0, offset));
+  {
+    relocate(src2.rspec());
+    IncompressibleRegion ir(this);
+    int32_t offset;
+    la_patchable(t0, src2, offset);
+    ld(t0, Address(t0, offset));
+  }
   beq(src1, t0, equal);
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -989,8 +989,6 @@ int MacroAssembler::bitset_to_regs(unsigned int bitset, unsigned char* regs) {
 // Return the number of words pushed
 int MacroAssembler::push_reg(unsigned int bitset, Register stack) {
   DEBUG_ONLY(int words_pushed = 0;)
-  CompressibleRegion cr(this);
-
   unsigned char regs[32];
   int count = bitset_to_regs(bitset, regs);
   // reserve one slot to align for odd count
@@ -1011,8 +1009,6 @@ int MacroAssembler::push_reg(unsigned int bitset, Register stack) {
 
 int MacroAssembler::pop_reg(unsigned int bitset, Register stack) {
   DEBUG_ONLY(int words_popped = 0;)
-  CompressibleRegion cr(this);
-
   unsigned char regs[32];
   int count = bitset_to_regs(bitset, regs);
   // reserve one slot to align for odd count
@@ -1034,7 +1030,6 @@ int MacroAssembler::pop_reg(unsigned int bitset, Register stack) {
 // Push floating-point registers in the bitset supplied.
 // Return the number of words pushed
 int MacroAssembler::push_fp(unsigned int bitset, Register stack) {
-  CompressibleRegion cr(this);
   DEBUG_ONLY(int words_pushed = 0;)
   unsigned char regs[32];
   int count = bitset_to_regs(bitset, regs);
@@ -1055,7 +1050,6 @@ int MacroAssembler::push_fp(unsigned int bitset, Register stack) {
 }
 
 int MacroAssembler::pop_fp(unsigned int bitset, Register stack) {
-  CompressibleRegion cr(this);
   DEBUG_ONLY(int words_popped = 0;)
   unsigned char regs[32];
   int count = bitset_to_regs(bitset, regs);
@@ -1076,7 +1070,6 @@ int MacroAssembler::pop_fp(unsigned int bitset, Register stack) {
 }
 
 void MacroAssembler::push_call_clobbered_registers_except(RegSet exclude) {
-  CompressibleRegion cr(this);
   // Push integer registers x7, x10-x17, x28-x31.
   push_reg(RegSet::of(x7) + RegSet::range(x10, x17) + RegSet::range(x28, x31) - exclude, sp);
 
@@ -1091,7 +1084,6 @@ void MacroAssembler::push_call_clobbered_registers_except(RegSet exclude) {
 }
 
 void MacroAssembler::pop_call_clobbered_registers_except(RegSet exclude) {
-  CompressibleRegion cr(this);
   int offset = 0;
   for (int i = 0; i < 32; i++) {
     if (i <= f7->encoding() || i >= f28->encoding() || (i >= f10->encoding() && i <= f17->encoding())) {
@@ -1105,18 +1097,15 @@ void MacroAssembler::pop_call_clobbered_registers_except(RegSet exclude) {
 
 // Push all the integer registers, except zr(x0) & sp(x2) & gp(x3) & tp(x4).
 void MacroAssembler::pusha() {
-  CompressibleRegion cr(this);
   push_reg(RegSet::of(x1) + RegSet::range(x5, x31), sp);
 }
 
 // Pop all the integer registers, except zr(x0) & sp(x2) & gp(x3) & tp(x4).
 void MacroAssembler::popa() {
-  CompressibleRegion cr(this);
   pop_reg(RegSet::of(x1) + RegSet::range(x5, x31), sp);
 }
 
 void MacroAssembler::push_CPU_state() {
-  CompressibleRegion cr(this);
   // integer registers, except zr(x0) & ra(x1) & sp(x2) & gp(x3) & tp(x4)
   push_reg(RegSet::range(x5, x31), sp);
 
@@ -1128,8 +1117,6 @@ void MacroAssembler::push_CPU_state() {
 }
 
 void MacroAssembler::pop_CPU_state() {
-  CompressibleRegion cr(this);
-
   // float registers
   for (int i = 0; i < 32; i++) {
     fld(as_FloatRegister(i), Address(sp, i * wordSize));

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -842,8 +842,11 @@ private:
     if (NearCpool) {
       ld(dest, const_addr);
     } else {
-      int32_t offset = 0;
-      la_patchable(dest, InternalAddress(const_addr.target()), offset);
+      InternalAddress target(const_addr.target());
+      relocate(target.rspec());
+      IncompressibleRegion ir(this);
+      int32_t offset;
+      la_patchable(dest, target, offset);
       ld(dest, Address(dest, offset));
     }
   }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -980,7 +980,6 @@ void MachBreakpointNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
 
 void MachBreakpointNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   MacroAssembler _masm(&cbuf);
-  Assembler::CompressibleRegion cr(&_masm);
   __ ebreak();
 }
 
@@ -1238,7 +1237,6 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
 
   if (cbuf != NULL) {
     MacroAssembler _masm(cbuf);
-    Assembler::CompressibleRegion cr(&_masm);
     switch (src_lo_rc) {
       case rc_int:
         if (dst_lo_rc == rc_int) {  // gpr --> gpr copy
@@ -1793,7 +1791,6 @@ encode %{
 
   enc_class riscv_enc_li_imm(iRegIorL dst, immIorL src) %{
     MacroAssembler _masm(&cbuf);
-    Assembler::CompressibleRegion cr(&_masm);
     int64_t con = (int64_t)$src$$constant;
     Register dst_reg = as_Register($dst$$reg);
     __ mv(dst_reg, con);
@@ -1820,7 +1817,6 @@ encode %{
 
   enc_class riscv_enc_mov_p1(iRegP dst) %{
     MacroAssembler _masm(&cbuf);
-    Assembler::CompressibleRegion cr(&_masm);
     Register dst_reg = as_Register($dst$$reg);
     __ mv(dst_reg, 1);
   %}
@@ -2247,14 +2243,12 @@ encode %{
 
   enc_class riscv_enc_tail_call(iRegP jump_target) %{
     MacroAssembler _masm(&cbuf);
-    Assembler::CompressibleRegion cr(&_masm);
     Register target_reg = as_Register($jump_target$$reg);
     __ jr(target_reg);
   %}
 
   enc_class riscv_enc_tail_jmp(iRegP jump_target) %{
     MacroAssembler _masm(&cbuf);
-    Assembler::CompressibleRegion cr(&_masm);
     Register target_reg = as_Register($jump_target$$reg);
     // exception oop should be in x10
     // ret addr has been popped into ra
@@ -2270,7 +2264,6 @@ encode %{
 
   enc_class riscv_enc_ret() %{
     MacroAssembler _masm(&cbuf);
-    Assembler::CompressibleRegion cr(&_masm);
     __ ret();
   %}
 
@@ -4243,7 +4236,6 @@ instruct loadI(iRegINoSp dst, memory mem)
   format %{ "lw  $dst, $mem\t# int, #@loadI" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4259,7 +4251,6 @@ instruct loadI2L(iRegLNoSp dst, memory mem)
   format %{ "lw  $dst, $mem\t# int, #@loadI2L" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ lw(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4290,7 +4281,6 @@ instruct loadL(iRegLNoSp dst, memory mem)
   format %{ "ld  $dst, $mem\t# int, #@loadL" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ ld(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4321,7 +4311,6 @@ instruct loadP(iRegPNoSp dst, memory mem)
   format %{ "ld  $dst, $mem\t# ptr, #@loadP" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ ld(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4352,7 +4341,6 @@ instruct loadKlass(iRegPNoSp dst, memory mem)
   format %{ "ld  $dst, $mem\t# class, #@loadKlass" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ ld(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4398,7 +4386,6 @@ instruct loadD(fRegD dst, memory mem)
   format %{ "fld  $dst, $mem\t# double, #@loadD" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ fld(as_FloatRegister($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4697,7 +4684,6 @@ instruct storeI(iRegIorL2I src, memory mem)
   format %{ "sw  $src, $mem\t# int, #@storeI" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ sw(as_Register($src$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4727,7 +4713,6 @@ instruct storeL(iRegL src, memory mem)
   format %{ "sd  $src, $mem\t# long, #@storeL" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ sd(as_Register($src$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4758,7 +4743,6 @@ instruct storeP(iRegP src, memory mem)
   format %{ "sd  $src, $mem\t# ptr, #@storeP" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ sd(as_Register($src$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4789,7 +4773,6 @@ instruct storeN(iRegN src, memory mem)
   format %{ "sw  $src, $mem\t# compressed ptr, #@storeN" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ sw(as_Register($src$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4836,7 +4819,6 @@ instruct storeD(fRegD src, memory mem)
   format %{ "fsd  $src, $mem\t# double, #@storeD" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ fsd(as_FloatRegister($src$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -4852,7 +4834,6 @@ instruct storeNKlass(iRegN src, memory mem)
   format %{ "sw  $src, $mem\t# compressed klass ptr, #@storeNKlass" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ sw(as_Register($src$$reg), Address(as_Register($mem$$base), $mem$$disp));
   %}
 
@@ -6135,7 +6116,6 @@ instruct addI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   format %{ "addw  $dst, $src1, $src2\t#@addI_reg_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ addw(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
@@ -6151,7 +6131,6 @@ instruct addI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immIAdd src2) %{
   format %{ "addiw  $dst, $src1, $src2\t#@addI_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     int32_t con = (int32_t)$src2$$constant;
     __ addiw(as_Register($dst$$reg),
              as_Register($src1$$reg),
@@ -6168,7 +6147,6 @@ instruct addI_reg_imm_l2i(iRegINoSp dst, iRegL src1, immIAdd src2) %{
   format %{ "addiw  $dst, $src1, $src2\t#@addI_reg_imm_l2i" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ addiw(as_Register($dst$$reg),
              as_Register($src1$$reg),
              $src2$$constant);
@@ -6185,7 +6163,6 @@ instruct addP_reg_reg(iRegPNoSp dst, iRegP src1, iRegL src2) %{
   format %{ "add $dst, $src1, $src2\t# ptr, #@addP_reg_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ add(as_Register($dst$$reg),
            as_Register($src1$$reg),
            as_Register($src2$$reg));
@@ -6201,7 +6178,6 @@ instruct lShiftL_regI_immGE32(iRegLNoSp dst, iRegI src, uimmI6_ge32 scale) %{
   format %{ "slli  $dst, $src, $scale & 63\t#@lShiftL_regI_immGE32" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ slli(as_Register($dst$$reg), as_Register($src$$reg), $scale$$constant & 63);
   %}
 
@@ -6217,7 +6193,6 @@ instruct addP_reg_imm(iRegPNoSp dst, iRegP src1, immLAdd src2) %{
   format %{ "addi  $dst, $src1, $src2\t# ptr, #@addP_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     // src2 is imm, so actually call the addi
     __ add(as_Register($dst$$reg),
            as_Register($src1$$reg),
@@ -6234,7 +6209,6 @@ instruct addL_reg_reg(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   format %{ "add  $dst, $src1, $src2\t#@addL_reg_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ add(as_Register($dst$$reg),
            as_Register($src1$$reg),
            as_Register($src2$$reg));
@@ -6250,7 +6224,6 @@ instruct addL_reg_imm(iRegLNoSp dst, iRegL src1, immLAdd src2) %{
   format %{ "addi  $dst, $src1, $src2\t#@addL_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     // src2 is imm, so actually call the addi
     __ add(as_Register($dst$$reg),
            as_Register($src1$$reg),
@@ -6268,7 +6241,6 @@ instruct subI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   format %{ "subw  $dst, $src1, $src2\t#@subI_reg_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ subw(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
@@ -6285,7 +6257,6 @@ instruct subI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immISub src2) %{
   format %{ "addiw  $dst, $src1, -$src2\t#@subI_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     // src2 is imm, so actually call the addiw
     __ subw(as_Register($dst$$reg),
             as_Register($src1$$reg),
@@ -6302,7 +6273,6 @@ instruct subL_reg_reg(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   format %{ "sub  $dst, $src1, $src2\t#@subL_reg_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ sub(as_Register($dst$$reg),
            as_Register($src1$$reg),
            as_Register($src2$$reg));
@@ -6318,7 +6288,6 @@ instruct subL_reg_imm(iRegLNoSp dst, iRegL src1, immLSub src2) %{
   format %{ "addi  $dst, $src1, -$src2\t#@subL_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     // src2 is imm, so actually call the addi
     __ sub(as_Register($dst$$reg),
            as_Register($src1$$reg),
@@ -6448,7 +6417,6 @@ instruct signExtractL(iRegLNoSp dst, iRegL src1, immI_63 div1, immI_63 div2) %{
   format %{ "srli $dst, $src1, $div1\t# long signExtract, #@signExtractL" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ srli(as_Register($dst$$reg), as_Register($src1$$reg), 63);
   %}
   ins_pipe(ialu_reg_shift);
@@ -6604,7 +6572,6 @@ instruct lShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
   format %{ "slli  $dst, $src1, ($src2 & 0x3f)\t#@lShiftL_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     // the shift amount is encoded in the lower
     // 6 bits of the I-immediate field for RV64I
     __ slli(as_Register($dst$$reg),
@@ -6640,7 +6607,6 @@ instruct urShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
   format %{ "srli  $dst, $src1, ($src2 & 0x3f)\t#@urShiftL_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     // the shift amount is encoded in the lower
     // 6 bits of the I-immediate field for RV64I
     __ srli(as_Register($dst$$reg),
@@ -6659,7 +6625,6 @@ instruct urShiftP_reg_imm(iRegLNoSp dst, iRegP src1, immI src2) %{
   format %{ "srli  $dst, p2x($src1), ($src2 & 0x3f)\t#@urShiftP_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     // the shift amount is encoded in the lower
     // 6 bits of the I-immediate field for RV64I
     __ srli(as_Register($dst$$reg),
@@ -6695,7 +6660,6 @@ instruct rShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
   format %{ "srai  $dst, $src1, ($src2 & 0x3f)\t#@rShiftL_reg_imm" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     // the shift amount is encoded in the lower
     // 6 bits of the I-immediate field for RV64I
     __ srai(as_Register($dst$$reg),
@@ -7197,7 +7161,6 @@ instruct andI_reg_reg(iRegINoSp dst, iRegI src1, iRegI src2) %{
 
   ins_cost(ALU_COST);
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ andr(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
@@ -7214,7 +7177,6 @@ instruct andI_reg_imm(iRegINoSp dst, iRegI src1, immIAdd src2) %{
 
   ins_cost(ALU_COST);
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ andi(as_Register($dst$$reg),
             as_Register($src1$$reg),
             (int32_t)($src2$$constant));
@@ -7231,7 +7193,6 @@ instruct orI_reg_reg(iRegINoSp dst, iRegI src1, iRegI src2) %{
 
   ins_cost(ALU_COST);
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ orr(as_Register($dst$$reg),
            as_Register($src1$$reg),
            as_Register($src2$$reg));
@@ -7264,7 +7225,6 @@ instruct xorI_reg_reg(iRegINoSp dst, iRegI src1, iRegI src2) %{
 
   ins_cost(ALU_COST);
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ xorr(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
@@ -7297,7 +7257,6 @@ instruct andL_reg_reg(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 
   ins_cost(ALU_COST);
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ andr(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
@@ -7314,7 +7273,6 @@ instruct andL_reg_imm(iRegLNoSp dst, iRegL src1, immLAdd src2) %{
 
   ins_cost(ALU_COST);
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ andi(as_Register($dst$$reg),
             as_Register($src1$$reg),
             (int32_t)($src2$$constant));
@@ -7331,7 +7289,6 @@ instruct orL_reg_reg(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 
   ins_cost(ALU_COST);
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ orr(as_Register($dst$$reg),
            as_Register($src1$$reg),
            as_Register($src2$$reg));
@@ -7364,7 +7321,6 @@ instruct xorL_reg_reg(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 
   ins_cost(ALU_COST);
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ xorr(as_Register($dst$$reg),
             as_Register($src1$$reg),
             as_Register($src2$$reg));
@@ -7565,7 +7521,6 @@ instruct castX2P(iRegPNoSp dst, iRegL src) %{
   format %{ "mv  $dst, $src\t# long -> ptr, #@castX2P" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     if ($dst$$reg != $src$$reg) {
       __ mv(as_Register($dst$$reg), as_Register($src$$reg));
     }
@@ -7581,7 +7536,6 @@ instruct castP2X(iRegLNoSp dst, iRegP src) %{
   format %{ "mv  $dst, $src\t# ptr -> long, #@castP2X" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     if ($dst$$reg != $src$$reg) {
       __ mv(as_Register($dst$$reg), as_Register($src$$reg));
     }
@@ -7692,7 +7646,6 @@ instruct convI2UL_reg_reg(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask)
   format %{ "zero_extend $dst, $src, 32\t# i2ul, #@convI2UL_reg_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ zero_extend(as_Register($dst$$reg), as_Register($src$$reg), 32);
   %}
 
@@ -7847,7 +7800,6 @@ instruct convP2I(iRegINoSp dst, iRegP src) %{
   format %{ "zero_extend $dst, $src, 32\t# ptr -> int, #@convP2I" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ zero_extend($dst$$Register, $src$$Register, 32);
   %}
 
@@ -7865,7 +7817,6 @@ instruct convN2I(iRegINoSp dst, iRegN src)
   format %{ "mv  $dst, $src\t# compressed ptr -> int, #@convN2I" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ mv($dst$$Register, $src$$Register);
   %}
 
@@ -7962,7 +7913,6 @@ instruct MoveF2I_stack_reg(iRegINoSp dst, stackSlotF src) %{
   format %{ "lw  $dst, $src\t#@MoveF2I_stack_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ lw(as_Register($dst$$reg), Address(sp, $src$$disp));
   %}
 
@@ -7999,7 +7949,6 @@ instruct MoveD2L_stack_reg(iRegLNoSp dst, stackSlotD src) %{
   format %{ "ld  $dst, $src\t#@MoveD2L_stack_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ ld(as_Register($dst$$reg), Address(sp, $src$$disp));
   %}
 
@@ -8018,7 +7967,6 @@ instruct MoveL2D_stack_reg(fRegD dst, stackSlotL src) %{
   format %{ "fld  $dst, $src\t#@MoveL2D_stack_reg" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ fld(as_FloatRegister($dst$$reg), Address(sp, $src$$disp));
   %}
 
@@ -8055,7 +8003,6 @@ instruct MoveI2F_reg_stack(stackSlotF dst, iRegI src) %{
   format %{ "sw  $src, $dst\t#@MoveI2F_reg_stack" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ sw(as_Register($src$$reg), Address(sp, $dst$$disp));
   %}
 
@@ -8074,7 +8021,6 @@ instruct MoveD2L_reg_stack(stackSlotL dst, fRegD src) %{
   format %{ "fsd  $dst, $src\t#@MoveD2L_reg_stack" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ fsd(as_FloatRegister($src$$reg), Address(sp, $dst$$disp));
   %}
 
@@ -8093,7 +8039,6 @@ instruct MoveL2D_reg_stack(stackSlotD dst, iRegL src) %{
   format %{ "sd  $src, $dst\t#@MoveL2D_reg_stack" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     __ sd(as_Register($src$$reg), Address(sp, $dst$$disp));
   %}
 
@@ -10235,7 +10180,6 @@ instruct ShouldNotReachHere() %{
   format %{ "#@ShouldNotReachHere" %}
 
   ins_encode %{
-    Assembler::CompressibleRegion cr(&_masm);
     if (is_reachable()) {
       __ halt();
     }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1832,8 +1832,13 @@ encode %{
     unsigned long align = (unsigned long)page & 0xfff;
     assert(align == 0, "polling page must be page aligned");
     Register dst_reg = as_Register($dst$$reg);
-    __ la_patchable(dst_reg, Address(page, relocInfo::poll_type), offset);
-    __ addi(dst_reg, dst_reg, offset);
+    Address target(page, relocInfo::poll_type);
+    {
+      __ relocate(target.rspec());
+      Assembler::IncompressibleRegion ir(&_masm);
+      __ la_patchable(dst_reg, target, offset);
+      __ addi(dst_reg, dst_reg, offset);
+    }
   %}
 
   enc_class riscv_enc_mov_byte_map_base(iRegP dst) %{

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -2401,9 +2401,14 @@ void TemplateTable::jvmti_post_field_access(Register cache, Register index,
     // take the time to call into the VM.
     Label L1;
     assert_different_registers(cache, index, x10);
-    int32_t offset = 0;
-    __ la_patchable(t0, ExternalAddress((address) JvmtiExport::get_field_access_count_addr()), offset);
-    __ lwu(x10, Address(t0, offset));
+    ExternalAddress target((address) JvmtiExport::get_field_access_count_addr());
+    {
+      __ relocate(target.rspec());
+      Assembler::IncompressibleRegion ir(_masm);
+      int32_t offset;
+      __ la_patchable(t0, target, offset);
+      __ lwu(x10, Address(t0, offset));
+    }
 
     __ beqz(x10, L1);
 
@@ -2620,9 +2625,14 @@ void TemplateTable::jvmti_post_field_mod(Register cache, Register index, bool is
     // we take the time to call into the VM.
     Label L1;
     assert_different_registers(cache, index, x10);
-    int32_t offset = 0;
-    __ la_patchable(t0, ExternalAddress((address)JvmtiExport::get_field_modification_count_addr()), offset);
-    __ lwu(x10, Address(t0, offset));
+    ExternalAddress target((address)JvmtiExport::get_field_modification_count_addr());
+    {
+      __ relocate(target.rspec());
+      Assembler::IncompressibleRegion ir(_masm);
+      int32_t offset;
+      __ la_patchable(t0, target, offset);
+      __ lwu(x10, Address(t0, offset));
+    }
     __ beqz(x10, L1);
 
     __ get_cache_and_index_at_bcp(c_rarg2, t0, 1);
@@ -2921,9 +2931,14 @@ void TemplateTable::jvmti_post_fast_field_mod()
     // Check to see if a field modification watch has been set before
     // we take the time to call into the VM.
     Label L2;
-    int32_t offset = 0;
-    __ la_patchable(t0, ExternalAddress((address)JvmtiExport::get_field_modification_count_addr()), offset);
-    __ lwu(c_rarg3, Address(t0, offset));
+    ExternalAddress target((address)JvmtiExport::get_field_modification_count_addr());
+    {
+      __ relocate(target.rspec());
+      Assembler::IncompressibleRegion ir(_masm);
+      int32_t offset;
+      __ la_patchable(t0, target, offset);
+      __ lwu(c_rarg3, Address(t0, offset));
+    }
     __ beqz(c_rarg3, L2);
     __ pop_ptr(x9);                  // copy the object pointer from tos
     __ verify_oop(x9);
@@ -3059,9 +3074,14 @@ void TemplateTable::fast_accessfield(TosState state)
     // Check to see if a field access watch has been set before we
     // take the time to call into the VM.
     Label L1;
-    int32_t offset = 0;
-    __ la_patchable(t0, ExternalAddress((address)JvmtiExport::get_field_access_count_addr()), offset);
-    __ lwu(x12, Address(t0, offset));
+    ExternalAddress target((address)JvmtiExport::get_field_access_count_addr());
+    {
+      __ relocate(target.rspec());
+      Assembler::IncompressibleRegion ir(_masm);
+      int32_t offset;
+      __ la_patchable(t0, target, offset);
+      __ lwu(x12, Address(t0, offset));
+    }
     __ beqz(x12, L1);
     // access constant pool cache entry
     __ get_cache_entry_pointer_at_bcp(c_rarg2, t1, 1);


### PR DESCRIPTION
Hi,
Please help review this backport to riscv-port-jdk11u.
This backport contains multiple issues:
- [8295110: RISC-V: Mark out relocations as incompressible](https://bugs.openjdk.org/browse/JDK-8295110)
- [8305112: RISC-V: Typo fix for RVC description](https://bugs.openjdk.org/browse/JDK-8305112)
- [8295396: RISC-V: Cleanup useless CompressibleRegions](https://bugs.openjdk.org/browse/JDK-8295396)
- [8305512: RISC-V: Enable RVC extension by default on](https://bugs.openjdk.org/browse/JDK-8305512)

The original patch cannot be directly applied because of riscv-port-jdk11u do not have ZGC andsome minor conflict resolution.
Another conflict is that we do not have the refactoring `8295270: RISC-V: Clean up and refactoring for assembler functions` on 11u.

It's also worth mentioning that there are some changes to the `8295110` implementation because jdk11u uses gnu++98 which cannot use lambda.

Testing:

- Tier1 passed without new failure on lp4a (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8295110](https://bugs.openjdk.org/browse/JDK-8295110): RISC-V: Mark out relocations as incompressible (**Enhancement** - P4)
 * [JDK-8305112](https://bugs.openjdk.org/browse/JDK-8305112): RISC-V: Typo fix for RVC description (**Enhancement** - P5)
 * [JDK-8295396](https://bugs.openjdk.org/browse/JDK-8295396): RISC-V: Cleanup useless CompressibleRegions (**Enhancement** - P4)
 * [JDK-8305512](https://bugs.openjdk.org/browse/JDK-8305512): RISC-V: Enable RVC extension by default on supported hardware (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk11u.git pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.org/riscv-port-jdk11u.git pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk11u/pull/45.diff">https://git.openjdk.org/riscv-port-jdk11u/pull/45.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk11u/pull/45#issuecomment-2537616805)
</details>
